### PR TITLE
Align image display to top of main pane

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -105,7 +105,8 @@ h1 {
   width: 100%;
   height: calc(100vh - 72px);
   display: grid;
-  place-items: center;
+  justify-items: center;
+  align-items: start;
   border: 1px dashed #4c566a;
   border-radius: 10px;
   background: #171b22;


### PR DESCRIPTION
### Motivation
- Display images at the top of the main pane instead of vertically centering them so previews appear upper-aligned within the frame.

### Description
- Modified `static/styles.css` to replace `place-items: center;` with `justify-items: center;` and `align-items: start;` in the `.image-frame` rule to preserve horizontal centering while top-aligning content.

### Testing
- Ran `python -m py_compile app.py` which completed successfully.
- Launched the app and captured a browser automation screenshot to visually verify the image is top-aligned (screenshot artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ade10f948832b9c954534523c8f36)