### PR TITLE
docs: add note for image display test root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ python app.py /path/to/image-dir
 ```sh
 python app.py /path/to/image-dir --host 0.0.0.0 --port 8000
 ```
+
+## 画像表示テスト用ディレクトリ
+画像の表示テストを行う場合は、ルートディレクトリに `test/resources/image-root` を指定してください。
+
+```sh
+python app.py test/resources/image-root
+```


### PR DESCRIPTION
### Motivation
- ドキュメントに画像表示テスト用のルートディレクトリを明記して、開発者やレビュー担当者が簡単にローカルで表示確認できるようにするため。 

### Description
- `README.md` に `画像表示テスト用ディレクトリ` セクションを追加し、ルートに `test/resources/image-root` を指定する例と `python app.py test/resources/image-root` の実行例を追記しました。 

### Testing
- ドキュメントのみの変更のためユニットテストは実行しておらず、`git add` と `git commit` によるファイル更新が正常に完了しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae3058e9c832b95195fe2e0c4e171)