### PR TITLE
Enable independent scrolling for sidebar image list

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -11,14 +11,19 @@ body {
   margin: 0;
   background: #101216;
   color: #eceff4;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .app {
   display: flex;
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
 }
 
 .sidebar {
+  display: flex;
+  flex-direction: column;
   width: 320px;
   background: #1b1f27;
   border-right: 1px solid #2f3845;
@@ -76,6 +81,9 @@ h1 {
   padding: 0;
   display: grid;
   gap: 6px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 #image-list button {


### PR DESCRIPTION
### Motivation
- Prevent the entire page/main pane from scrolling when the sidebar list is long so the main image preview stays fixed.

### Description
- Constrain the app viewport by setting `body` to `height: 100vh` and `overflow: hidden` to avoid page-level scrolling.
- Make `.app` a fixed-height container with `height: 100%` and `overflow: hidden` so the layout does not grow beyond the viewport.
- Convert `.sidebar` into a column flex container so its children can layout vertically and the list can expand.
- Allow the image list (`#image-list`) to take remaining sidebar space with `flex: 1; min-height: 0; overflow-y: auto;` so the sidebar alone scrolls.

### Testing
- Ran `python -m py_compile app.py` which succeeded.
- Attempted `python -m py_compile app.py static/app.js` which failed due to `static/app.js` being JavaScript (expected); this was then narrowed to `python -m py_compile app.py` which passed.
- Started the server with `python app.py test/resources/image_root --host 0.0.0.0 --port 8000` which served successfully and a Playwright script captured a screenshot to confirm the sidebar scroll behavior (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b166ad130832bb188c15c5e272e39)