### PR TITLE
メインペインの画像表示をフレームなしの全面表示に変更

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -70,7 +70,7 @@ async function loadImages(subdir) {
   currentIndex = -1;
   mainImage.removeAttribute('src');
   mainImage.style.display = 'none';
-  emptyMessage.style.display = 'block';
+  emptyMessage.style.display = 'grid';
 
   try {
     const data = await fetchJson(`/api/images/${encodePathSegment(subdir)}`);

--- a/static/index.html
+++ b/static/index.html
@@ -21,10 +21,8 @@
       </aside>
 
       <main class="main">
-        <div class="image-frame">
-          <img id="main-image" alt="画像プレビュー" />
-          <p id="empty-message">左のリストから画像を選択してください</p>
-        </div>
+        <img id="main-image" alt="画像プレビュー" />
+        <p id="empty-message">左のリストから画像を選択してください</p>
         <p id="status"></p>
       </main>
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -96,34 +96,34 @@ h1 {
 
 .main {
   flex: 1;
-  display: grid;
-  place-items: center;
-  padding: 20px;
-}
-
-.image-frame {
-  width: 100%;
-  height: calc(100vh - 72px);
-  display: grid;
-  justify-items: center;
-  align-items: start;
-  border: 1px dashed #4c566a;
-  border-radius: 10px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  position: relative;
   background: #171b22;
 }
 
 #main-image {
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
+  flex: 1;
+  min-height: 0;
   object-fit: contain;
   display: none;
 }
 
 #empty-message {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
   color: #9aa5b1;
 }
 
 #status {
-  margin-top: 12px;
+  margin: 8px 0 0;
   color: #9aa5b1;
 }


### PR DESCRIPTION
### Motivation
- メインペインの周囲のフレーム要素を廃止して、選択した画像をペイン全体に表示することで表示領域を最大化するため。

### Description
- `static/index.html` で `image-frame` ラッパーを削除し、`<img id="main-image">` と `<p id="empty-message">` を `main` の直下に移動しました。 
- `static/styles.css` でメイン領域をフレックスレイアウトに変更し、画像を `width: 100%` / `height: 100%` / `object-fit: contain` で表示するように調整してフレーム風の境界線・角丸を削除しました。 
- 空状態メッセージをオーバーレイ中央表示するために `#empty-message` を絶対配置のグリッド表示に変更しました。 
- `static/app.js` で画像が未選択時に空メッセージを再表示する際の `display` を `grid` に変更しました。 

### Testing
- 実行チェックとして `python -m py_compile app.py` を実行して成功しました。 
- `python app.py test/resources/image_root --host 0.0.0.0 --port 8000` でサーバを起動して動作させることを確認しました。 
- Playwright で `http://127.0.0.1:8000` を開きスクリーンショットを取得して表示レイアウトを目視確認（`artifacts/main-pane-full.png`）しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b16cee7cc832b9021d8b5e4b2913d)