### PR TITLE
docs: update image_root references and add preview checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# プレビュー確認の定型手順
+
+- 起動コマンド: `python app.py test/resources/image_root`
+- アクセスURL: `http://localhost:8000`
+- 初期状態の期待値: サブディレクトリ選択後に画像一覧が表示され、1枚目がメイン表示される
+- 失敗時の確認項目: `image_root` のスペル（`-` ではなく `_`）

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ python app.py /path/to/image-dir --host 0.0.0.0 --port 8000
 ```
 
 ## 画像表示テスト用ディレクトリ
-画像の表示テストを行う場合は、ルートディレクトリに `test/resources/image-root` を指定してください。
+画像の表示テストを行う場合は、ルートディレクトリに `test/resources/image_root` を指定してください。
+テスト画像の先頭1枚が初期表示される想定です。
 
 ```sh
-python app.py test/resources/image-root
+python app.py test/resources/image_root
 ```


### PR DESCRIPTION
### Motivation
- Unify the test directory notation to avoid confusion between `image-root` and `image_root` when running the preview workflow.
- Provide a simple, reproducible checklist at the repository root to make manual preview verification straightforward.

### Description
- Replaced occurrences of `test/resources/image-root` with `test/resources/image_root` in `README.md` and updated the example startup command to match.
- Added one line to the `README.md` test section noting that the first test image is expected to be shown initially.
- Added a new `AGENTS.md` at the repository root containing the preview checklist with the startup command, access URL, expected initial state, and a spelling check for `image_root`.

### Testing
- Verified file updates with `rg -n 'image-root|image_root|localhost:8000|1枚目' README.md AGENTS.md`, which returned the updated occurrences successfully.
- Confirmed working tree status with `git status --short`, and staged/committed the changes with `git add` and `git commit`, which completed successfully.
- Created the PR metadata using the local `make_pr` tool, which produced the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b1adacfa0832b82e07a424d6cba43)