### PR TITLE
feat: メインペインのホイール操作で画像切り替えを追加

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5,6 +5,7 @@ const imageList = document.getElementById('image-list');
 const mainImage = document.getElementById('main-image');
 const emptyMessage = document.getElementById('empty-message');
 const status = document.getElementById('status');
+const mainPane = document.querySelector('.main');
 
 let images = [];
 let currentSubdir = '';
@@ -128,5 +129,26 @@ document.addEventListener('keydown', (event) => {
     showImage((currentIndex - 1 + images.length) % images.length);
   }
 });
+
+if (mainPane) {
+  mainPane.addEventListener(
+    'wheel',
+    (event) => {
+      if (images.length === 0 || event.deltaY === 0) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (event.deltaY > 0) {
+        showImage((currentIndex + 1) % images.length);
+        return;
+      }
+
+      showImage((currentIndex - 1 + images.length) % images.length);
+    },
+    { passive: false }
+  );
+}
 
 init();


### PR DESCRIPTION
## 概要
メインペイン上でマウスホイールを操作したときに、表示画像を切り替えられるようにしました。

- 下方向にホイール: 次の画像へ
- 上方向にホイール: 前の画像へ
- 既存のキーボード操作（←/→）と同様に末尾/先頭でループ

## 変更内容

- `.main` 要素に `wheel` イベントリスナーを追加
- `event.deltaY > 0` で次画像、`event.deltaY < 0` で前画像へ遷移
- `event.preventDefault() + { passive: false }` で、ホイール時の不要なスクロールを抑止
- `.main` が存在しない場合に備えて `if (mainPane)` でガード

## 対象ファイル
- static/app.js

## 動作確認
- `node --check static/app.js`
- `python app.py test/resources/image_root --port 8000`
- `curl -s http://localhost:8000/api/subdirectories`
- `curl -s http://localhost:8000/api/images/dir1`

## 補足
ブラウザ自動テスト（Playwright）でのスクリーンショット取得は環境要因でタイムアウトしたため、手元確認結果をベースにしています。