### PR TITLE
Reverse sorting order for subdirectory list API

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,7 @@ class ImageViewHandler(SimpleHTTPRequestHandler):
         path = parsed.path
 
         if path == "/api/subdirectories":
-            subdirs = [entry.name for entry in sorted(self.base_dir.iterdir()) if entry.is_dir()]
+            subdirs = [entry.name for entry in sorted(self.base_dir.iterdir(), reverse=True) if entry.is_dir()]
             return self._send_json({"subdirectories": subdirs})
 
         if path.startswith("/api/images/"):


### PR DESCRIPTION
### Motivation
- Return subdirectory names in reverse-sorted order so the UI displays subdirectories in descending order.

### Description
- Updated `/api/subdirectories` in `app.py` to use `sorted(self.base_dir.iterdir(), reverse=True)` when building the subdirectory list.

### Testing
- Started the app with `python app.py test/resources/image_root` and verified `curl -s http://localhost:8000/api/subdirectories` returned `{"subdirectories": ["dir2", "dir1"]}`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b24baebb4832b88eb19fbefba5092)