### PR TITLE
Document workaround for Codex browser-tool 'Not Found' screenshots in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ python app.py /path/to/image-dir --host 0.0.0.0 --port 8000
 ```sh
 python app.py test/resources/image_root
 ```
+
+## Codex環境でスクリーンショットが `Not Found` になる場合の回避策
+Codex の browser tool（Playwright 実行環境）では、`localhost` の解決先が
+シェルで `python app.py ...` を起動した環境と一致しない場合があります。
+このとき、`http://localhost:8000` にアクセスしてもアプリではなく `Not Found` を取得することがあります。
+
+回避策:
+
+1. まずシェル側でアプリが正常起動していることを確認する。
+
+```sh
+python app.py test/resources/image_root
+curl -i http://localhost:8000/
+curl -i http://localhost:8000/api/subdirectories
+```
+
+2. browser tool でスクリーンショットを取る前に、`/api/subdirectories` の HTTP ステータスが 200 か確認する。
+3. browser tool 側で `localhost` が到達不能な場合は、スクリーンショット運用を行わず、
+   代替として `curl` の結果（HTTP 200 と JSON 応答）を確認証跡として扱う。
+4. 起動引数のパスを必ず `test/resources/image_root`（`_`）にする（`image-root` は誤り）。


### PR DESCRIPTION
### Motivation
- Document a workaround for cases where the Codex browser tool (Playwright) resolves `localhost` differently than the shell-run server, which can cause screenshots to show `Not Found` even when the app is running. 

### Description
- Added a README section that explains the issue and instructs to verify the app with `curl` (`/` and `/api/subdirectories`), gate screenshot capture on a 200 response, use `curl` output as fallback evidence when the browser tool cannot reach `localhost`, and re-emphasize using the `test/resources/image_root` path. 

### Testing
- Started the app with `python app.py test/resources/image_root` and verified that `http://localhost:8000/` and `http://localhost:8000/api/subdirectories` returned HTTP 200 (HTML and JSON respectively), and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b25779684832ba951976282bb1a74)