### PR TITLE
Add subdirectory reload control in sidebar

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -15,7 +15,10 @@
         </div>
 
         <label for="subdir-select">フォルダ</label>
-        <select id="subdir-select"></select>
+        <div class="subdir-controls">
+          <select id="subdir-select"></select>
+          <button id="reload-subdirs" type="button" aria-label="サブディレクトリを再取得">↻</button>
+        </div>
 
         <ul id="image-list"></ul>
       </aside>

--- a/static/styles.css
+++ b/static/styles.css
@@ -46,7 +46,7 @@ body {
 
 .sidebar.collapsed h1,
 .sidebar.collapsed label,
-.sidebar.collapsed select,
+.sidebar.collapsed .subdir-controls,
 .sidebar.collapsed #image-list {
   display: none;
 }
@@ -65,14 +65,34 @@ h1 {
   cursor: pointer;
 }
 
-#subdir-select {
-  width: 100%;
-  padding: 8px;
+.subdir-controls {
+  display: flex;
+  gap: 8px;
   margin: 8px 0 12px;
+}
+
+#subdir-select {
+  flex: 1;
+  min-width: 0;
+  padding: 8px;
   background: #252c37;
   color: inherit;
   border: 1px solid #465264;
   border-radius: 6px;
+}
+
+#reload-subdirs {
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #252c37;
+  color: inherit;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+#reload-subdirs:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 #image-list {


### PR DESCRIPTION
## Summary
- add a reload button next to the subdirectory select control in the sidebar
- implement `refreshSubdirectories()` to re-fetch `/api/subdirectories` and keep the current selection when possible
- update UI state handling for empty/missing subdirectory cases and disable the reload button while fetching

## Validation
- Started app with `python app.py test/resources/image_root`
- Opened `http://127.0.0.1:8000` and captured screenshot showing the new reload button

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b28aee0ec832bac271f106bce459b)