### PR TITLE
feat: サイドメニュー幅をドラッグで可変に

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7,12 +7,32 @@ const emptyMessage = document.getElementById('empty-message');
 const status = document.getElementById('status');
 const mainPane = document.querySelector('.main');
 
+const sidebarResizer = document.getElementById('sidebar-resizer');
+
+const SIDEBAR_MIN_WIDTH = 220;
+const SIDEBAR_MAX_WIDTH = 720;
+const SIDEBAR_DEFAULT_WIDTH = 320;
+let sidebarWidth = SIDEBAR_DEFAULT_WIDTH;
+
+function applySidebarWidth(width) {
+  const clampedWidth = Math.min(
+    SIDEBAR_MAX_WIDTH,
+    Math.max(SIDEBAR_MIN_WIDTH, width)
+  );
+  sidebarWidth = clampedWidth;
+  document.querySelector('.app').style.setProperty('--sidebar-width', `${clampedWidth}px`);
+}
+
 let images = [];
 let currentSubdir = '';
 let currentIndex = -1;
 
 toggleSidebarBtn.addEventListener('click', () => {
-  sidebar.classList.toggle('collapsed');
+  const isCollapsed = sidebar.classList.toggle('collapsed');
+
+  if (!isCollapsed) {
+    applySidebarWidth(sidebarWidth);
+  }
 });
 
 async function fetchJson(url) {
@@ -152,3 +172,36 @@ if (mainPane) {
 }
 
 init();
+
+
+if (sidebarResizer) {
+  const stopResizing = () => {
+    sidebarResizer.classList.remove('dragging');
+    document.body.style.userSelect = '';
+    window.removeEventListener('mousemove', onResize);
+    window.removeEventListener('mouseup', stopResizing);
+  };
+
+  const onResize = (event) => {
+    if (sidebar.classList.contains('collapsed')) {
+      return;
+    }
+
+    applySidebarWidth(event.clientX);
+  };
+
+  sidebarResizer.addEventListener('mousedown', (event) => {
+    if (sidebar.classList.contains('collapsed')) {
+      return;
+    }
+
+    event.preventDefault();
+    sidebarResizer.classList.add('dragging');
+    document.body.style.userSelect = 'none';
+
+    window.addEventListener('mousemove', onResize);
+    window.addEventListener('mouseup', stopResizing);
+  });
+}
+
+applySidebarWidth(SIDEBAR_DEFAULT_WIDTH);

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,8 @@
         <ul id="image-list"></ul>
       </aside>
 
+      <div id="sidebar-resizer" class="sidebar-resizer" aria-hidden="true"></div>
+
       <main class="main">
         <img id="main-image" alt="画像プレビュー" />
         <p id="empty-message">左のリストから画像を選択してください</p>

--- a/static/styles.css
+++ b/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 .app {
+  --sidebar-width: 320px;
   display: flex;
   height: 100%;
   overflow: hidden;
@@ -24,12 +25,30 @@ body {
 .sidebar {
   display: flex;
   flex-direction: column;
-  width: 320px;
+  width: var(--sidebar-width);
+  min-width: 220px;
+  max-width: 60vw;
   background: #1b1f27;
   border-right: 1px solid #2f3845;
   padding: 16px;
   transition: width 0.2s ease, padding 0.2s ease;
   overflow: hidden;
+}
+
+.sidebar-resizer {
+  width: 8px;
+  cursor: col-resize;
+  background: #161a22;
+  border-right: 1px solid #2f3845;
+}
+
+.sidebar-resizer:hover,
+.sidebar-resizer.dragging {
+  background: #222834;
+}
+
+.sidebar.collapsed + .sidebar-resizer {
+  cursor: default;
 }
 
 .sidebar.collapsed {


### PR DESCRIPTION
### Motivation
- サイドバーを固定幅から可変幅にしてユーザーが幅を調整できるようにするための変更です。

### Description
- `static/index.html` にリサイズハンドル要素 `#sidebar-resizer` を追加しました。
- `static/styles.css` を更新して `--sidebar-width` CSS カスタムプロパティを導入し、`.sidebar` を固定幅から可変幅へ変更し、リサイズハンドルのスタイル（通常・ホバー・ドラッグ中）を追加しました。最小幅は `220px`、最大幅は `60vw`（JS 側でも 720px 上限）です。
- `static/app.js` に `applySidebarWidth` 関数とマウスドラッグによるリサイズ処理を追加し、折りたたみトグル解除時に直前幅を再適用する処理を実装しました。

### Testing
- `node --check static/app.js` は成功しました。✅
- `python -m py_compile app.py` は成功しました。✅
- サーバ起動確認で `python app.py test/resources/image_root` を実行し、`curl -s http://localhost:8000/api/subdirectories` で JSON 応答を確認しました。✅
- ブラウザ自動操作（Playwright）による画面キャプチャ取得を試行しましたが、環境差異により `http://localhost:8000` から `Not Found` が返りスクリーンショット取得は失敗しました（自動ブラウザ経由の接続での失敗）。❌

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b2a081a8c832b9bdd0c74a8af7b37)