### PR TITLE
Add subdirectory home screen and separate viewer route

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,9 @@ class ImageViewHandler(SimpleHTTPRequestHandler):
             if entry.is_file() and entry.suffix.lower() in IMAGE_EXTENSIONS
         ]
 
+    def _subdirectory_entries(self) -> list[str]:
+        return [entry.name for entry in sorted(self.base_dir.iterdir(), reverse=True) if entry.is_dir()]
+
     def _serve_image(self, send_body: bool) -> None:
         path = urlparse(self.path).path
         image_path = path.removeprefix("/api/image/")
@@ -89,8 +92,7 @@ class ImageViewHandler(SimpleHTTPRequestHandler):
         path = parsed.path
 
         if path == "/api/subdirectories":
-            subdirs = [entry.name for entry in sorted(self.base_dir.iterdir(), reverse=True) if entry.is_dir()]
-            return self._send_json({"subdirectories": subdirs})
+            return self._send_json({"subdirectories": self._subdirectory_entries()})
 
         if path.startswith("/api/images/"):
             subdir = path.removeprefix("/api/images/")
@@ -108,6 +110,8 @@ class ImageViewHandler(SimpleHTTPRequestHandler):
             return self._serve_image(send_body=True)
 
         if path == "/":
+            self.path = "/home.html"
+        elif path == "/viewer":
             self.path = "/index.html"
 
         return super().do_GET()

--- a/static/home.html
+++ b/static/home.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Image View WebUI - Home</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="home">
+      <h1>サブディレクトリ一覧</h1>
+      <p class="home-description">閲覧するフォルダを選択してください。</p>
+      <button id="reload-subdirs" type="button" class="reload-button">再読み込み</button>
+      <ul id="subdir-list" class="subdir-list"></ul>
+      <p id="home-status" class="home-status"></p>
+    </main>
+
+    <script src="/home.js" defer></script>
+  </body>
+</html>

--- a/static/home.js
+++ b/static/home.js
@@ -1,0 +1,55 @@
+const subdirList = document.getElementById('subdir-list');
+const homeStatus = document.getElementById('home-status');
+const reloadButton = document.getElementById('reload-subdirs');
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function setStatus(message) {
+  homeStatus.textContent = message;
+}
+
+function renderSubdirectories(subdirectories) {
+  subdirList.innerHTML = '';
+
+  subdirectories.forEach((name) => {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = `/viewer?subdir=${encodeURIComponent(name)}`;
+    link.textContent = name;
+    li.appendChild(link);
+    subdirList.appendChild(li);
+  });
+}
+
+async function refreshSubdirectories() {
+  reloadButton.disabled = true;
+  setStatus('読み込み中...');
+
+  try {
+    const data = await fetchJson('/api/subdirectories');
+    const subdirectories = data.subdirectories;
+
+    if (subdirectories.length === 0) {
+      renderSubdirectories([]);
+      setStatus('サブディレクトリがありません。');
+      return;
+    }
+
+    renderSubdirectories(subdirectories);
+    setStatus(`${subdirectories.length} 件のサブディレクトリがあります。`);
+  } catch (error) {
+    setStatus(`サブディレクトリ一覧の取得に失敗しました: ${error.message}`);
+  } finally {
+    reloadButton.disabled = false;
+  }
+}
+
+reloadButton.addEventListener('click', refreshSubdirectories);
+
+refreshSubdirectories();

--- a/static/index.html
+++ b/static/index.html
@@ -14,18 +14,15 @@
           <button id="toggle-sidebar" aria-label="toggle sidebar">☰</button>
         </div>
 
-        <label for="subdir-select">フォルダ</label>
-        <div class="subdir-controls">
-          <select id="subdir-select"></select>
-          <button id="reload-subdirs" type="button" aria-label="サブディレクトリを再取得">↻</button>
-        </div>
+        <a class="home-link" href="/">← サブディレクトリ一覧へ</a>
+        <p id="selected-subdir" class="selected-subdir"></p>
 
         <ul id="image-list"></ul>
       </aside>
 
       <main class="main">
         <img id="main-image" alt="画像プレビュー" />
-        <p id="empty-message">左のリストから画像を選択してください</p>
+        <p id="empty-message">画像がありません</p>
         <p id="status"></p>
       </main>
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -11,13 +11,12 @@ body {
   margin: 0;
   background: #101216;
   color: #eceff4;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
 }
 
 .app {
   display: flex;
-  height: 100%;
+  height: 100vh;
   overflow: hidden;
 }
 
@@ -45,8 +44,8 @@ body {
 }
 
 .sidebar.collapsed h1,
-.sidebar.collapsed label,
-.sidebar.collapsed .subdir-controls,
+.sidebar.collapsed .home-link,
+.sidebar.collapsed .selected-subdir,
 .sidebar.collapsed #image-list {
   display: none;
 }
@@ -65,34 +64,19 @@ h1 {
   cursor: pointer;
 }
 
-.subdir-controls {
-  display: flex;
-  gap: 8px;
-  margin: 8px 0 12px;
+.home-link {
+  color: #88c0d0;
+  text-decoration: none;
+  margin-bottom: 8px;
 }
 
-#subdir-select {
-  flex: 1;
-  min-width: 0;
-  padding: 8px;
-  background: #252c37;
-  color: inherit;
-  border: 1px solid #465264;
-  border-radius: 6px;
+.home-link:hover {
+  text-decoration: underline;
 }
 
-#reload-subdirs {
-  border: 1px solid #465264;
-  border-radius: 6px;
-  background: #252c37;
-  color: inherit;
-  padding: 8px 10px;
-  cursor: pointer;
-}
-
-#reload-subdirs:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.selected-subdir {
+  margin: 0 0 12px;
+  color: #9aa5b1;
 }
 
 #image-list {
@@ -153,5 +137,58 @@ h1 {
 
 #status {
   margin: 8px 0 0;
+  color: #9aa5b1;
+}
+
+.home {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 16px;
+}
+
+.home-description {
+  margin: 8px 0 16px;
+  color: #9aa5b1;
+}
+
+.reload-button {
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #252c37;
+  color: inherit;
+  padding: 8px 12px;
+  cursor: pointer;
+  margin-bottom: 16px;
+}
+
+.reload-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.subdir-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.subdir-list a {
+  display: block;
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #252c37;
+  color: inherit;
+  text-decoration: none;
+  padding: 12px;
+}
+
+.subdir-list a:hover {
+  border-color: #88c0d0;
+}
+
+.home-status {
+  margin-top: 16px;
   color: #9aa5b1;
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated home screen that lists available subdirectories so users can choose a folder before entering the viewer. 
- Simplify the viewer UI by making it a dedicated route that opens a single selected subdirectory, improving UX and navigation.

### Description
- Backend routing was changed so `/` now serves `home.html` and `/viewer` serves the existing viewer page, and a new `_subdirectory_entries` helper exposes the subdirectory list for `/api/subdirectories`. 
- Added `static/home.html` and `static/home.js` to show the subdirectory list and link into the viewer via `?subdir=`. 
- Updated `static/index.html` and `static/app.js` so the viewer reads the target subdirectory from the query param, displays the selected folder, and replaces the previous select/reload controls with a back link. 
- Updated `static/styles.css` to add styles for the home list and adjust viewer sidebar presentation.

### Testing
- Ran `python -m py_compile app.py` which succeeded. 
- Started the server with `python app.py test/resources/image_root` and confirmed it served the test image directory. 
- Verified API and pages with `curl` calls: `/`, `/api/subdirectories`, `/viewer?subdir=dir1`, and `/api/images/dir1` all returned expected responses. 
- Captured UI screenshots via Playwright for both the home page and viewer page which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b397ee164832bb1b773d7a6117f9b)