### PR TITLE
Add thumbnail previews to subdirectory cards on home page

### DIFF
--- a/static/home.html
+++ b/static/home.html
@@ -11,7 +11,7 @@
       <h1>サブディレクトリ一覧</h1>
       <p class="home-description">閲覧するフォルダを選択してください。</p>
       <button id="reload-subdirs" type="button" class="reload-button">再読み込み</button>
-      <ul id="subdir-list" class="subdir-list"></ul>
+      <ul id="subdir-list" class="subdir-list" aria-live="polite"></ul>
       <p id="home-status" class="home-status"></p>
     </main>
 

--- a/static/home.js
+++ b/static/home.js
@@ -2,6 +2,8 @@ const subdirList = document.getElementById('subdir-list');
 const homeStatus = document.getElementById('home-status');
 const reloadButton = document.getElementById('reload-subdirs');
 
+let thumbnailObserver;
+
 async function fetchJson(url) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -14,16 +16,140 @@ function setStatus(message) {
   homeStatus.textContent = message;
 }
 
+function addEmptyThumbnailMessage(thumbnailContainer) {
+  thumbnailContainer.innerHTML = '';
+  const emptyMessage = document.createElement('p');
+  emptyMessage.className = 'subdir-no-images';
+  emptyMessage.textContent = '画像なし';
+  thumbnailContainer.appendChild(emptyMessage);
+}
+
+function createThumbnailElement(subdirectory, filename) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'subdir-thumb-slot';
+
+  const img = document.createElement('img');
+  img.className = 'subdir-thumb';
+  img.loading = 'lazy';
+  img.decoding = 'async';
+  img.src = `/api/image/${encodeURIComponent(subdirectory)}/${encodeURIComponent(filename)}`;
+  img.alt = `${subdirectory} のサムネイル ${filename}`;
+  img.onerror = () => {
+    img.classList.add('is-hidden');
+    wrapper.classList.add('is-fallback');
+  };
+
+  wrapper.appendChild(img);
+  return wrapper;
+}
+
+async function loadSubdirectoryThumbnails(card) {
+  if (card.dataset.thumbnailsLoaded === 'true' || card.dataset.loadingThumbnails === 'true') {
+    return;
+  }
+
+  card.dataset.loadingThumbnails = 'true';
+  const subdirectory = card.dataset.subdirectory;
+  const thumbnailContainer = card.querySelector('.subdir-thumbs');
+
+  try {
+    const data = await fetchJson(`/api/images/${encodeURIComponent(subdirectory)}`);
+    const images = data.images.slice(0, 5);
+
+    thumbnailContainer.innerHTML = '';
+
+    if (images.length === 0) {
+      addEmptyThumbnailMessage(thumbnailContainer);
+    } else {
+      images.forEach((filename) => {
+        thumbnailContainer.appendChild(createThumbnailElement(subdirectory, filename));
+      });
+    }
+
+    card.dataset.thumbnailsLoaded = 'true';
+  } catch (_error) {
+    addEmptyThumbnailMessage(thumbnailContainer);
+    card.dataset.thumbnailsLoaded = 'true';
+  } finally {
+    delete card.dataset.loadingThumbnails;
+  }
+}
+
+function observeCardThumbnails(card) {
+  if (thumbnailObserver) {
+    thumbnailObserver.observe(card);
+    return;
+  }
+
+  // IntersectionObserver がない環境では描画後に順次ロードする。
+  loadSubdirectoryThumbnails(card);
+}
+
+function setupThumbnailObserver() {
+  if (thumbnailObserver) {
+    thumbnailObserver.disconnect();
+  }
+
+  if ('IntersectionObserver' in window) {
+    thumbnailObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          const card = entry.target;
+          loadSubdirectoryThumbnails(card);
+          thumbnailObserver.unobserve(card);
+        });
+      },
+      {
+        root: null,
+        rootMargin: '120px 0px',
+        threshold: 0.1,
+      },
+    );
+  } else {
+    thumbnailObserver = null;
+  }
+}
+
+function createSubdirectoryCard(name) {
+  const li = document.createElement('li');
+
+  const link = document.createElement('a');
+  link.className = 'subdir-card';
+  link.href = `/viewer?subdir=${encodeURIComponent(name)}`;
+  link.dataset.subdirectory = name;
+
+  const meta = document.createElement('div');
+  meta.className = 'subdir-meta';
+
+  const title = document.createElement('p');
+  title.className = 'subdir-name';
+  title.textContent = name;
+  meta.appendChild(title);
+
+  const thumbs = document.createElement('div');
+  thumbs.className = 'subdir-thumbs';
+
+  const loadingMessage = document.createElement('p');
+  loadingMessage.className = 'subdir-loading';
+  loadingMessage.textContent = '画像を読み込み中...';
+  thumbs.appendChild(loadingMessage);
+
+  link.append(meta, thumbs);
+  li.appendChild(link);
+
+  observeCardThumbnails(link);
+  return li;
+}
+
 function renderSubdirectories(subdirectories) {
   subdirList.innerHTML = '';
+  setupThumbnailObserver();
 
   subdirectories.forEach((name) => {
-    const li = document.createElement('li');
-    const link = document.createElement('a');
-    link.href = `/viewer?subdir=${encodeURIComponent(name)}`;
-    link.textContent = name;
-    li.appendChild(link);
-    subdirList.appendChild(li);
+    subdirList.appendChild(createSubdirectoryCard(name));
   });
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -174,7 +174,7 @@ h1 {
   gap: 8px;
 }
 
-.subdir-list a {
+.subdir-card {
   display: block;
   border: 1px solid #465264;
   border-radius: 6px;
@@ -184,8 +184,56 @@ h1 {
   padding: 12px;
 }
 
-.subdir-list a:hover {
+.subdir-card:hover {
   border-color: #88c0d0;
+}
+
+.subdir-meta {
+  margin-bottom: 8px;
+}
+
+.subdir-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.subdir-thumbs {
+  display: flex;
+  gap: 8px;
+  min-height: 56px;
+  align-items: center;
+}
+
+.subdir-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 6px;
+  object-fit: cover;
+  background: #1b1f27;
+}
+
+.subdir-thumb-slot {
+  width: 56px;
+  height: 56px;
+  border-radius: 6px;
+  overflow: hidden;
+  flex: 0 0 auto;
+  background: #1b1f27;
+}
+
+.subdir-thumb-slot.is-fallback {
+  border: 1px dashed #465264;
+}
+
+.subdir-thumb.is-hidden {
+  display: none;
+}
+
+.subdir-loading,
+.subdir-no-images {
+  margin: 0;
+  color: #9aa5b1;
+  font-size: 0.9rem;
 }
 
 .home-status {


### PR DESCRIPTION
### Motivation
- Improve the home subdirectory list UI to provide visual previews so users can quickly see example images for each folder.
- Avoid layout shifts and excessive network load by fetching only a small number of thumbnails and loading them lazily.

### Description
- Update `static/home.html` to make the subdirectory list a card container and add `aria-live="polite"` to the list for accessibility.
- Replace the simple link list with card markup built in `static/home.js` (`li > a.subdir-card > div.subdir-meta + div.subdir-thumbs`) and fetch image filenames per directory via `fetchJson('/api/images/' + encodeURIComponent(subdir))` then `images.slice(0, 5)`.
- Construct thumbnail URLs as `/api/image/${encodeURIComponent(subdir)}/${encodeURIComponent(filename)}`, create up to 5 `img` elements per card, and add an `onerror` handler to hide broken images and mark the slot as a fallback to preserve layout.
- Show a localized empty-state message (`画像なし`) when a directory has no images and add a simple lazy-loading strategy using `IntersectionObserver` with a non-`IntersectionObserver` fallback that loads after render.
- Add styling in `static/styles.css` for thumbnail rows and slots (fixed 56×56 size, rounded corners, `object-fit: cover`, spacing, and fallback visuals).

### Testing
- Started the app with `python app.py test/resources/image_root` and confirmed the server served the test image root successfully. (success)
- Queried the APIs with `curl -s http://127.0.0.1:8000/api/subdirectories` and `curl -s http://127.0.0.1:8000/api/images/dir1` to validate JSON responses for subdirectory and image list endpoints. (success)
- Captured a browser screenshot of the updated home page using Playwright with Firefox to validate rendered cards and thumbnails. (screenshot capture success)
- Attempted a Playwright Chromium run which failed to launch in the environment due to a Chromium crash (`SIGSEGV`). (environment failure, not a code regression)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3e6e8e30832bb871a105524e14a0)