### PR TITLE
サブディレクトリのサムネイルを168x168に拡大

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -200,21 +200,21 @@ h1 {
 .subdir-thumbs {
   display: flex;
   gap: 8px;
-  min-height: 56px;
+  min-height: 168px;
   align-items: center;
 }
 
 .subdir-thumb {
-  width: 56px;
-  height: 56px;
+  width: 168px;
+  height: 168px;
   border-radius: 6px;
   object-fit: cover;
   background: #1b1f27;
 }
 
 .subdir-thumb-slot {
-  width: 56px;
-  height: 56px;
+  width: 168px;
+  height: 168px;
   border-radius: 6px;
   overflow: hidden;
   flex: 0 0 auto;


### PR DESCRIPTION
### Motivation
- サブディレクトリカード内のサムネイルが小さく視認性が低いため、表示サイズを `56x56` から `168x168` に拡大するための変更です。

### Description
- `static/styles.css` の `.subdir-thumbs` の `min-height` を `168px` に変更してサムネイル領域の高さを確保しました。
- 同ファイルの `.subdir-thumb` と `.subdir-thumb-slot` の `width` と `height` をそれぞれ `168px` に更新しました。

### Testing
- 実行：`python -m compileall app.py static` — 成功しました。
- 実行：`python app.py test/resources/image_root` でサーバ起動を確認しました（アプリは起動しページにアクセス可能でした）。
- 実行：Playwright（Chromium）による自動スクリーンショット検証は環境側のブラウザクラッシュで失敗しました。
- 実行：Playwright（Firefox）による自動スクリーンショット検証は成功し、プレビュー画像が生成されました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b42c47af4832b83f340a0be74ed46)