### PR TITLE
ディレクトリ一覧のサムネイル表示枚数を7枚に変更

### DIFF
--- a/static/home.js
+++ b/static/home.js
@@ -3,6 +3,7 @@ const homeStatus = document.getElementById('home-status');
 const reloadButton = document.getElementById('reload-subdirs');
 
 let thumbnailObserver;
+const SUBDIR_THUMBNAIL_COUNT = 7;
 
 async function fetchJson(url) {
   const response = await fetch(url);
@@ -54,7 +55,7 @@ async function loadSubdirectoryThumbnails(card) {
 
   try {
     const data = await fetchJson(`/api/images/${encodeURIComponent(subdirectory)}`);
-    const images = data.images.slice(0, 5);
+    const images = data.images.slice(0, SUBDIR_THUMBNAIL_COUNT);
 
     thumbnailContainer.innerHTML = '';
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -141,7 +141,7 @@ h1 {
 }
 
 .home {
-  max-width: 720px;
+  width: max-content;
   margin: 0 auto;
   padding: 40px 16px;
 }
@@ -169,9 +169,14 @@ h1 {
 .subdir-list {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 auto;
   display: grid;
   gap: 8px;
+  width: max-content;
+}
+
+.subdir-list > li {
+  width: max-content;
 }
 
 .subdir-card {

--- a/static/styles.css
+++ b/static/styles.css
@@ -182,6 +182,7 @@ h1 {
   color: inherit;
   text-decoration: none;
   padding: 12px;
+  overflow: hidden;
 }
 
 .subdir-card:hover {
@@ -202,6 +203,8 @@ h1 {
   gap: 8px;
   min-height: 168px;
   align-items: center;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .subdir-thumb {


### PR DESCRIPTION
### Motivation
- ディレクトリ一覧カードで表示するサムネイル枚数を5枚から7枚に増やして一覧の視認性を向上させるため。 

### Description
- `static/home.js` に `SUBDIR_THUMBNAIL_COUNT = 7` を追加し、画像取得時の `slice(0, 5)` を `slice(0, SUBDIR_THUMBNAIL_COUNT)` に置換しました。 

### Testing
- サーバ起動での動作確認を行うために `python app.py test/resources/image_root` を実行してページを表示できることを確認しました（成功）。
- ブラウザ操作を自動化して一覧ページのスクリーンショットを取得するスクリプトを Playwright (Firefox) で実行し描画を確認しました（成功）。
- `python -m py_compile app.py` を実行して構文チェックを行いエラーがないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699076ecaad0832b8c55fd5229ef7483)