### PR TITLE
ディレクトリ一覧でサブディレクトリ名を変更可能にする

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -175,18 +175,52 @@ h1 {
 }
 
 .subdir-card {
-  display: block;
   border: 1px solid #465264;
   border-radius: 6px;
   background: #252c37;
+  padding: 12px;
+}
+
+.subdir-link {
+  display: block;
   color: inherit;
   text-decoration: none;
-  padding: 12px;
 }
 
 .subdir-card:hover {
   border-color: #88c0d0;
 }
+
+.subdir-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+}
+
+.subdir-rename-input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #1b1f27;
+  color: inherit;
+  padding: 6px 8px;
+}
+
+.subdir-rename-button {
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #2d3440;
+  color: inherit;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.subdir-rename-button:disabled,
+.subdir-rename-input:disabled {
+  opacity: 0.6;
+}
+
 
 .subdir-meta {
   margin-bottom: 8px;


### PR DESCRIPTION
### Motivation
- ホームのサブディレクトリ一覧画面から直接ディレクトリ名を変更できるようにするための機能追加です。 
- サーバ側で安全にリネーム処理を行い、誤った入力やパス走査を防止することを目的としています。 
- UI側で即時に状態表示と一覧更新を行い操作性を向上させます。

### Description
- サーバに `POST /api/subdirectories/rename` エンドポイントを追加し、リクエストボディの JSON (`old_name`, `new_name`) を受け取って直接子ディレクトリをリネームする処理を実装しました (`app.py` の `_rename_subdirectory` / `do_POST`)。 
- 名前検証 (`_valid_subdirectory_name`) と `_safe_path` を組み合わせてパス走査や不正な名前、直接子以外の操作を拒否する入力検証とエラーレスポンスを返すようにしました。 
- ホーム画面の各サブディレクトリカードにテキスト入力と「名前変更」ボタンを追加し、`renameSubdirectory` 関数から上記 API を呼び出して成功時に一覧を再読み込みする動作を実装しました (`static/home.js`)。 
- 入力欄とボタンに合わせてスタイルを追加し、カード構造をリンク領域 (`.subdir-link`) と操作領域 (`.subdir-actions`) に分離する CSS 変更を行いました (`static/styles.css`)。

### Testing
- `python -m py_compile app.py` を実行してサーバ側の構文チェックは成功しました。 
- 一時ディレクトリへ `test/resources/image_root` をコピーしてサーバを起動後に `curl` で `/api/subdirectories` の取得と `POST /api/subdirectories/rename` による `dir1`→`dir1-renamed` のリネームを実行したところ、リスト更新が確認でき成功しました。 
- ブラウザベースのスクリーンショット取得を試行する Playwright スクリプトは実行環境のブラウザプロセスがクラッシュして失敗しましたが、API とサーバ挙動の自動的な確認は上記 `curl` 系で成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699076d6a8ec832b9dd838b3c15d11d3)