### PR TITLE
Enable renaming subdirectories from the directory list page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -196,6 +196,31 @@ h1 {
   gap: 8px;
 }
 
+
+.subdir-row {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.subdir-row .subdir-card {
+  flex: 1;
+}
+
+.subdir-rename-button {
+  border: 1px solid #465264;
+  border-radius: 6px;
+  background: #252c37;
+  color: inherit;
+  padding: 0 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.subdir-rename-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 .subdir-card {
   display: block;
   border: 1px solid #465264;


### PR DESCRIPTION
### Motivation
- Allow users to rename image subdirectories directly from the directory-list (home) UI to improve workflow when organizing image folders.

### Description
- Add a backend API `PUT /api/subdirectories/<current_name>` that reads JSON body and renames the corresponding directory with validation for empty names, `.`/`..`, path separators, and conflicts in `app.py`.
- Implement safe JSON body parsing with `_read_json_body` and return structured JSON on success (`renamed_from`/`renamed_to`).
- Add a "名前変更" button to each subdirectory card in `static/home.js` which prompts for a new name, calls the new API, and refreshes the list on success.
- Add layout and button styles in `static/styles.css` so the rename button is displayed side-by-side with the navigation card.

### Testing
- Ran `python -m py_compile app.py` to verify Python syntax; it succeeded.
- Verified `static/home.js` is valid JS via `node -e "new Function(require('fs').readFileSync('static/home.js','utf8'))"`; it succeeded.
- Performed manual API validation while running the app: renamed `dir2 -> dir2_tmp` and back `dir2_tmp -> dir2` using `curl` against `PUT /api/subdirectories/<name>` and confirmed the subdirectory list updated; these operations succeeded.
- Captured an updated UI screenshot with a browser tool to verify the button layout (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907e655aec832bb39752e9b6d3c86e)