### PR TITLE
閲覧画面を簡素化：サイドバー削除し下部に操作バーを配置

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,8 +8,10 @@
   </head>
   <body>
     <main class="main">
-      <img id="main-image" alt="画像プレビュー" />
-      <p id="empty-message">画像がありません</p>
+      <div class="image-stage">
+        <img id="main-image" alt="画像プレビュー" />
+        <p id="empty-message">画像がありません</p>
+      </div>
       <div id="status-bar" class="status-bar">
         <a class="home-link" href="/">← ディレクトリ一覧へ</a>
         <span id="selected-subdir" class="selected-subdir"></span>

--- a/static/index.html
+++ b/static/index.html
@@ -7,25 +7,18 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <div class="app">
-      <aside id="sidebar" class="sidebar expanded">
-        <div class="sidebar-header">
-          <h1>Image Viewer</h1>
-          <button id="toggle-sidebar" aria-label="toggle sidebar">☰</button>
-        </div>
-
-        <a class="home-link" href="/">← サブディレクトリ一覧へ</a>
-        <p id="selected-subdir" class="selected-subdir"></p>
-
-        <ul id="image-list"></ul>
-      </aside>
-
-      <main class="main">
-        <img id="main-image" alt="画像プレビュー" />
-        <p id="empty-message">画像がありません</p>
-        <p id="status"></p>
-      </main>
-    </div>
+    <main class="main">
+      <img id="main-image" alt="画像プレビュー" />
+      <p id="empty-message">画像がありません</p>
+      <div id="status-bar" class="status-bar">
+        <a class="home-link" href="/">← ディレクトリ一覧へ</a>
+        <span id="selected-subdir" class="selected-subdir"></span>
+        <span id="image-index"></span>
+        <span id="image-name"></span>
+        <button id="delete-current-image" type="button" class="image-delete-button">削除</button>
+      </div>
+      <p id="status" class="status-message"></p>
+    </main>
 
     <script src="/app.js" defer></script>
   </body>

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,21 +7,15 @@
   box-sizing: border-box;
 }
 
-html,
 body {
   margin: 0;
-  width: 100%;
-  height: 100%;
-}
-
-body {
   background: #101216;
   color: #eceff4;
-  overflow: hidden;
+  min-height: 100vh;
 }
 
 .main {
-  height: 100dvh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -29,25 +23,23 @@ body {
   gap: 8px;
   background: #171b22;
   overflow: hidden;
-  min-height: 0;
 }
 
 .image-stage {
   flex: 1;
   min-height: 0;
   width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
   position: relative;
   overflow: hidden;
 }
 
 #main-image {
-  width: 100%;
-  height: 100%;
   max-width: 100%;
   max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
   display: none;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -14,122 +14,7 @@ body {
   min-height: 100vh;
 }
 
-.app {
-  display: flex;
-  height: 100vh;
-  overflow: hidden;
-}
-
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  width: 320px;
-  background: #1b1f27;
-  border-right: 1px solid #2f3845;
-  padding: 16px;
-  transition: width 0.2s ease, padding 0.2s ease;
-  overflow: hidden;
-}
-
-.sidebar.collapsed {
-  width: 56px;
-  padding-inline: 8px;
-}
-
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.sidebar.collapsed h1,
-.sidebar.collapsed .home-link,
-.sidebar.collapsed .selected-subdir,
-.sidebar.collapsed #image-list {
-  display: none;
-}
-
-h1 {
-  font-size: 1rem;
-  margin: 0;
-}
-
-#toggle-sidebar {
-  border: 1px solid #4c566a;
-  border-radius: 6px;
-  background: #2d3440;
-  color: #eceff4;
-  padding: 4px 8px;
-  cursor: pointer;
-}
-
-.home-link {
-  color: #88c0d0;
-  text-decoration: none;
-  margin-bottom: 8px;
-}
-
-.home-link:hover {
-  text-decoration: underline;
-}
-
-.selected-subdir {
-  margin: 0 0 12px;
-  color: #9aa5b1;
-}
-
-#image-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 6px;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-}
-
-#image-list .image-list-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-#image-list .image-item-button {
-  width: 100%;
-  flex: 1;
-  text-align: left;
-  border: 1px solid #465264;
-  border-radius: 6px;
-  background: #252c37;
-  color: inherit;
-  padding: 8px;
-  cursor: pointer;
-}
-
-#image-list .image-item-button.active {
-  border-color: #88c0d0;
-  background: #3b4554;
-}
-
-#image-list .image-delete-button {
-  border: 1px solid #bf616a;
-  border-radius: 6px;
-  background: #5b2b33;
-  color: #f7d7db;
-  padding: 8px 10px;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-#image-list .image-delete-button:hover {
-  border-color: #d08770;
-  background: #70353f;
-}
-
 .main {
-  flex: 1;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -157,8 +42,62 @@ h1 {
   color: #9aa5b1;
 }
 
-#status {
+.status-bar {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-top: 1px solid #2f3845;
+  padding-top: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.home-link {
+  color: #88c0d0;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.home-link:hover {
+  text-decoration: underline;
+}
+
+.selected-subdir,
+#image-index,
+#image-name {
+  color: #9aa5b1;
+}
+
+#image-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.image-delete-button {
+  margin-left: auto;
+  border: 1px solid #bf616a;
+  border-radius: 6px;
+  background: #5b2b33;
+  color: #f7d7db;
+  padding: 8px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.image-delete-button:hover {
+  border-color: #d08770;
+  background: #70353f;
+}
+
+.image-delete-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-message {
   margin: 8px 0 0;
+  width: 100%;
   color: #9aa5b1;
 }
 
@@ -196,7 +135,6 @@ h1 {
   gap: 8px;
 }
 
-
 .subdir-row {
   display: flex;
   gap: 10px;
@@ -221,6 +159,7 @@ h1 {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
 .subdir-card {
   display: block;
   border: 1px solid #465264;
@@ -257,33 +196,4 @@ h1 {
   border-radius: 6px;
   object-fit: cover;
   background: #1b1f27;
-}
-
-.subdir-thumb-slot {
-  width: 168px;
-  height: 168px;
-  border-radius: 6px;
-  overflow: hidden;
-  flex: 0 0 auto;
-  background: #1b1f27;
-}
-
-.subdir-thumb-slot.is-fallback {
-  border: 1px dashed #465264;
-}
-
-.subdir-thumb.is-hidden {
-  display: none;
-}
-
-.subdir-loading,
-.subdir-no-images {
-  margin: 0;
-  color: #9aa5b1;
-  font-size: 0.9rem;
-}
-
-.home-status {
-  margin-top: 16px;
-  color: #9aa5b1;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -15,21 +15,31 @@ body {
 }
 
 .main {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
   padding: 12px;
-  position: relative;
+  gap: 8px;
   background: #171b22;
+  overflow: hidden;
+}
+
+.image-stage {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
 }
 
 #main-image {
-  width: 100%;
-  height: 100%;
-  flex: 1;
-  min-height: 0;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;
   display: none;
 }
@@ -44,6 +54,7 @@ body {
 
 .status-bar {
   width: 100%;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -96,8 +107,9 @@ body {
 }
 
 .status-message {
-  margin: 8px 0 0;
+  margin: 0;
   width: 100%;
+  flex-shrink: 0;
   color: #9aa5b1;
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,15 +7,21 @@
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
+  width: 100%;
+  height: 100%;
+}
+
+body {
   background: #101216;
   color: #eceff4;
-  min-height: 100vh;
+  overflow: hidden;
 }
 
 .main {
-  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -23,23 +29,25 @@ body {
   gap: 8px;
   background: #171b22;
   overflow: hidden;
+  min-height: 0;
 }
 
 .image-stage {
   flex: 1;
   min-height: 0;
   width: 100%;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
   overflow: hidden;
 }
 
 #main-image {
+  width: 100%;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
-  width: auto;
-  height: auto;
   object-fit: contain;
   display: none;
 }


### PR DESCRIPTION
### Motivation
- 閲覧画面を簡素化してUXを向上させるため、サイドバーを廃止し主要操作を画面下部にまとめる。 
- 要件に従い「ディレクトリ一覧へのリンク → フォルダ名 → 画像のインデクス/総枚数 → 画像名 → 削除ボタン」の順で表示するためのレイアウト変更を行う。

### Description
- `static/index.html` を差し替え、サイドバーとサムネイル一覧を削除してメイン画像表示＋下部のステータス/操作バーを追加した。 
- `static/styles.css` を更新して新しいフッターバーの横並びレイアウト、画像名の省略表示、削除ボタンのスタイルと無効化状態を追加した。 
- `static/app.js` のロジックを変更してサイドバー依存コード（リスト描画／トグル等）を削除し、現在表示中の画像に合わせてフッターを更新する `updateFooter` と「現在の画像を削除」する機能を実装した（矢印キー・ホイールでの移動は維持）。

### Testing
- `python -m py_compile app.py` を実行して構文チェックを行い成功した。 
- 開発サーバを `python app.py test/resources/image_root` で起動して `http://127.0.0.1:8000/?directory_id=dir1` を自動的に開き、Playwright でスクリーンショットを取得して表示が更新されたことを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990939e5968832b83c1b87eea769f0c)