### PR TITLE
chore: Add API tests for image handling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+httpx

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import threading
+from pathlib import Path
+
+import httpx
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import ImageViewHandler
+from http.server import ThreadingHTTPServer
+
+
+@pytest.fixture
+def copied_image_root(tmp_path: Path) -> Path:
+    source = Path("tests/resources/image_root")
+    destination = tmp_path / "image_root"
+    shutil.copytree(source, destination)
+    return destination
+
+
+@pytest.fixture
+def empty_image_root(tmp_path: Path) -> Path:
+    destination = tmp_path / "empty_image_root"
+    destination.mkdir()
+    return destination
+
+
+@pytest.fixture
+def api_client_factory():
+    clients: list[httpx.Client] = []
+    servers: list[ThreadingHTTPServer] = []
+    threads: list[threading.Thread] = []
+
+    def _start(base_dir: Path) -> httpx.Client:
+        handler_class = type(
+            "ConfiguredImageViewHandler",
+            (ImageViewHandler,),
+            {
+                "base_dir": base_dir,
+                "_id_to_path": {},
+                "_path_to_id": {},
+                "_resource_lock": threading.Lock(),
+            },
+        )
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler_class)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        host, port = server.server_address
+        client = httpx.Client(base_url=f"http://{host}:{port}")
+
+        clients.append(client)
+        servers.append(server)
+        threads.append(thread)
+        return client
+
+    yield _start
+
+    for client in clients:
+        client.close()
+    for server in servers:
+        server.shutdown()
+        server.server_close()
+    for thread in threads:
+        thread.join(timeout=2)

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+
+def _first_directory_id(client):
+    response = client.get("/api/subdirectories")
+    assert response.status_code == 200
+    subdirectories = response.json()["subdirectories"]
+    assert subdirectories
+    return subdirectories[0]["directory_id"]
+
+
+def _first_file_id(client, directory_id: str):
+    response = client.get(f"/api/images/{directory_id}")
+    assert response.status_code == 200
+    images = response.json()["images"]
+    assert images
+    return images[0]["file_id"]
+
+
+def test_get_subdirectories_when_non_empty(api_client_factory, copied_image_root):
+    client = api_client_factory(copied_image_root)
+
+    response = client.get("/api/subdirectories")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["subdirectories"], list)
+    assert len(data["subdirectories"]) == 2
+    assert all(isinstance(entry["directory_id"], str) for entry in data["subdirectories"])
+    assert all(isinstance(entry["name"], str) for entry in data["subdirectories"])
+
+
+def test_get_subdirectories_when_empty(api_client_factory, empty_image_root):
+    client = api_client_factory(empty_image_root)
+
+    response = client.get("/api/subdirectories")
+
+    assert response.status_code == 200
+    assert response.json() == {"subdirectories": []}
+
+
+def test_get_images_for_existing_and_missing_directory(api_client_factory, copied_image_root):
+    client = api_client_factory(copied_image_root)
+    directory_id = _first_directory_id(client)
+
+    success = client.get(f"/api/images/{directory_id}")
+    missing = client.get("/api/images/not-found-directory-id")
+
+    assert success.status_code == 200
+    payload = success.json()
+    assert payload["directory_id"] == directory_id
+    assert isinstance(payload["subdirectory"], str)
+    assert isinstance(payload["images"], list)
+    assert payload["images"]
+    assert all(isinstance(entry["file_id"], str) for entry in payload["images"])
+    assert all(isinstance(entry["name"], str) for entry in payload["images"])
+    assert missing.status_code == 404
+
+
+def test_get_and_head_image_contract(api_client_factory, copied_image_root):
+    client = api_client_factory(copied_image_root)
+    directory_id = _first_directory_id(client)
+    file_id = _first_file_id(client, directory_id)
+
+    get_response = client.get(f"/api/image/{file_id}")
+    assert get_response.status_code == 200
+    assert get_response.content
+    etag = get_response.headers["etag"]
+
+    not_modified = client.get(f"/api/image/{file_id}", headers={"If-None-Match": etag})
+    assert not_modified.status_code == 304
+
+    head_response = client.head(f"/api/image/{file_id}")
+    assert head_response.status_code == 200
+    assert head_response.content == b""
+
+    missing = client.get("/api/image/not-found-file-id")
+    assert missing.status_code == 404
+
+
+def test_delete_image_then_fetch_returns_404(api_client_factory, copied_image_root):
+    client = api_client_factory(copied_image_root)
+    directory_id = _first_directory_id(client)
+    file_id = _first_file_id(client, directory_id)
+
+    delete_response = client.delete(f"/api/image/{file_id}")
+    fetch_after_delete = client.get(f"/api/image/{file_id}")
+
+    assert delete_response.status_code == 200
+    assert delete_response.json()["file_id"] == file_id
+    assert fetch_after_delete.status_code == 404
+
+
+def test_put_subdirectory_rename_success_and_conflict(api_client_factory, copied_image_root):
+    client = api_client_factory(copied_image_root)
+
+    list_response = client.get("/api/subdirectories")
+    assert list_response.status_code == 200
+    subdirs = list_response.json()["subdirectories"]
+    assert len(subdirs) >= 2
+
+    rename_target = subdirs[0]
+    conflict_name = subdirs[1]["name"]
+
+    rename_response = client.put(
+        f"/api/subdirectories/{rename_target['directory_id']}",
+        json={"new_name": "renamed-dir"},
+    )
+    conflict_response = client.put(
+        f"/api/subdirectories/{rename_response.json()['directory_id']}",
+        json={"new_name": conflict_name},
+    )
+
+    assert rename_response.status_code == 200
+    renamed_payload = rename_response.json()
+    assert renamed_payload["renamed_from"] == rename_target["name"]
+    assert renamed_payload["renamed_to"] == "renamed-dir"
+    assert conflict_response.status_code == 409
+
+    refreshed = client.get("/api/subdirectories")
+    assert refreshed.status_code == 200
+    names = [entry["name"] for entry in refreshed.json()["subdirectories"]]
+    assert "renamed-dir" in names
+    assert rename_target["name"] not in names


### PR DESCRIPTION
Summary
tests/api/ を新規作成し、HTTP 契約ベースの API テストを追加しました（内部実装には依存せず、ID は API 応答から取得した値をそのまま利用）。

GET /api/subdirectories（空 / 非空）

GET /api/images/{directory_id}（存在 / 不存在）

GET/HEAD /api/image/{file_id}（200 / 304 / 404）

DELETE /api/image/{file_id}（削除後の再取得 404）

PUT /api/subdirectories/{directory_id}（rename 成功 / 競合失敗）

テスト用フィクスチャで tests/resources/image_root を毎回テンポラリへコピーし、削除や rename のような破壊的操作が元データに影響しないよう隔離しました。加えて、ローカルのエフェメラル HTTP サーバーと httpx.Client を立ち上げる共通 fixture を実装しました。.

開発用依存として pytest / httpx を requirements-dev.txt に追加しました。.