### PR TITLE
refactor: add semantic type aliases for API string fields

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -14,6 +14,7 @@ from app.models.schemas import (
     RenameDirectoryResponse,
     SubdirectoriesResponse,
 )
+from app.models.types import DirectoryId, FileId
 from app.services.image_service import (
     ConflictError,
     ImageService,
@@ -32,14 +33,14 @@ def create_api_router(service: ImageService) -> APIRouter:
         return SubdirectoriesResponse(subdirectories=service.list_subdirectories())
 
     @router.get("/images/{directory_id}", response_model=ImagesResponse)
-    def get_images(directory_id: str) -> ImagesResponse:
+    def get_images(directory_id: DirectoryId) -> ImagesResponse:
         try:
             directory, images = service.list_images(directory_id)
         except ResourceNotFoundError as exc:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND) from exc
         return ImagesResponse(directory_id=directory_id, subdirectory=directory.name, images=images)
 
-    def _build_image_response(file_id: str, request: Request, include_body: bool) -> Response:
+    def _build_image_response(file_id: FileId, request: Request, include_body: bool) -> Response:
         try:
             file_path = service.resolve_image(file_id)
         except ResourceNotFoundError as exc:
@@ -82,15 +83,15 @@ def create_api_router(service: ImageService) -> APIRouter:
         return FileResponse(path=file_path, media_type=content_type, headers=headers)
 
     @router.get("/image/{file_id}")
-    def get_image(file_id: str, request: Request) -> Response:
+    def get_image(file_id: FileId, request: Request) -> Response:
         return _build_image_response(file_id=file_id, request=request, include_body=True)
 
     @router.head("/image/{file_id}")
-    def head_image(file_id: str, request: Request) -> Response:
+    def head_image(file_id: FileId, request: Request) -> Response:
         return _build_image_response(file_id=file_id, request=request, include_body=False)
 
     @router.delete("/image/{file_id}", response_model=DeleteImageResponse)
-    def delete_image(file_id: str) -> DeleteImageResponse:
+    def delete_image(file_id: FileId) -> DeleteImageResponse:
         try:
             deleted_file = service.delete_image(file_id)
         except ResourceNotFoundError as exc:
@@ -103,7 +104,7 @@ def create_api_router(service: ImageService) -> APIRouter:
         return DeleteImageResponse(deleted=deleted_file.name, file_id=file_id)
 
     @router.put("/subdirectories/{directory_id}", response_model=RenameDirectoryResponse)
-    def rename_subdirectory(directory_id: str, payload: RenameDirectoryRequest) -> RenameDirectoryResponse:
+    def rename_subdirectory(directory_id: DirectoryId, payload: RenameDirectoryRequest) -> RenameDirectoryResponse:
         try:
             new_directory_id, renamed_from, renamed_to = service.rename_subdirectory(directory_id, payload.new_name)
         except ResourceNotFoundError as exc:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from app.models.types import DirectoryId, DirectoryName, FileId, FileName
+
 
 class DirectoryEntry(BaseModel):
-    directory_id: str
-    name: str
+    directory_id: DirectoryId
+    name: DirectoryName
 
 
 class ImageEntry(BaseModel):
-    file_id: str
-    name: str
+    file_id: FileId
+    name: FileName
 
 
 class SubdirectoriesResponse(BaseModel):
@@ -18,21 +20,21 @@ class SubdirectoriesResponse(BaseModel):
 
 
 class ImagesResponse(BaseModel):
-    directory_id: str
-    subdirectory: str
+    directory_id: DirectoryId
+    subdirectory: DirectoryName
     images: list[ImageEntry]
 
 
 class DeleteImageResponse(BaseModel):
-    deleted: str
-    file_id: str
+    deleted: FileName
+    file_id: FileId
 
 
 class RenameDirectoryRequest(BaseModel):
-    new_name: str
+    new_name: DirectoryName
 
 
 class RenameDirectoryResponse(BaseModel):
-    directory_id: str
-    renamed_from: str
-    renamed_to: str
+    directory_id: DirectoryId
+    renamed_from: DirectoryName
+    renamed_to: DirectoryName

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Annotated, TypeAlias
+
+from pydantic import StringConstraints
+
+DirectoryId: TypeAlias = str
+FileId: TypeAlias = str
+
+# ファイル名・ディレクトリ名はパス区切り文字を含まない前提。
+FileName: TypeAlias = Annotated[str, StringConstraints(min_length=1, pattern=r"^[^/\\]+$")]
+DirectoryName: TypeAlias = Annotated[str, StringConstraints(min_length=1, pattern=r"^[^/\\]+$")]

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from app.models.schemas import DirectoryEntry, ImageEntry
+from app.models.types import DirectoryId, DirectoryName, FileId
 from app.repositories.filesystem import FileSystemRepository
 
 
@@ -55,7 +56,7 @@ class ResourceRegistry:
             if resource_id is not None:
                 self._id_to_path.pop(resource_id, None)
 
-    def resolve(self, resource_id: str, *, base_dir: Path, expect_directory: bool) -> Path | None:
+    def resolve(self, resource_id: DirectoryId | FileId, *, base_dir: Path, expect_directory: bool) -> Path | None:
         with self._lock:
             path = self._id_to_path.get(resource_id)
 
@@ -81,7 +82,7 @@ class ImageService:
         subdirectories = self.repository.list_subdirectories(self.base_dir)
         return [DirectoryEntry(directory_id=self.registry.register(path), name=path.name) for path in subdirectories]
 
-    def list_images(self, directory_id: str) -> tuple[Path, list[ImageEntry]]:
+    def list_images(self, directory_id: DirectoryId) -> tuple[Path, list[ImageEntry]]:
         directory = self.registry.resolve(directory_id, base_dir=self.base_dir, expect_directory=True)
         if directory is None:
             raise ResourceNotFoundError
@@ -90,7 +91,7 @@ class ImageService:
         image_entries = [ImageEntry(file_id=self.registry.register(path), name=path.name) for path in images]
         return directory, image_entries
 
-    def resolve_image(self, file_id: str) -> Path:
+    def resolve_image(self, file_id: FileId) -> Path:
         file_path = self.registry.resolve(file_id, base_dir=self.base_dir, expect_directory=False)
         if file_path is None:
             raise ResourceNotFoundError
@@ -98,7 +99,7 @@ class ImageService:
             raise UnsupportedMediaTypeError
         return file_path
 
-    def delete_image(self, file_id: str) -> Path:
+    def delete_image(self, file_id: FileId) -> Path:
         file_path = self.resolve_image(file_id)
         try:
             self.repository.delete_file(file_path)
@@ -107,7 +108,9 @@ class ImageService:
         self.registry.discard(file_path)
         return file_path
 
-    def rename_subdirectory(self, directory_id: str, new_name: str) -> tuple[str, str, str]:
+    def rename_subdirectory(
+        self, directory_id: DirectoryId, new_name: DirectoryName
+    ) -> tuple[DirectoryId, DirectoryName, DirectoryName]:
         current_directory = self.registry.resolve(directory_id, base_dir=self.base_dir, expect_directory=True)
         if current_directory is None:
             raise ResourceNotFoundError

--- a/docs/agent-handoff/tasks/2026-02-22-api-string-field-type-aliases.md
+++ b/docs/agent-handoff/tasks/2026-02-22-api-string-field-type-aliases.md
@@ -1,0 +1,15 @@
+## Context Handoff
+- Goal: APIモデルで意味の異なる文字列を型エイリアスで明確化し、`deleted: str` を含むレスポンス項目の意図を読みやすくする。
+- Changes:
+  - `app/models/types.py` を追加し、`FileId` / `DirectoryId` / `FileName` / `DirectoryName` を定義。
+  - `app/models/schemas.py` の文字列フィールドを上記型へ置換（`deleted` は `FileName` へ変更）。
+  - `app/api/routes.py` と `app/services/image_service.py` の引数・戻り値注釈を追従更新。
+- Decisions:
+  - Decision: `FileName` / `DirectoryName` は `Annotated[str, StringConstraints(...)]` を採用。
+  - Rationale: 文字列の意味づけと同時に、パス区切り文字を含む不正値をPydanticで早期検知できるため。
+  - Impact: APIリクエスト/レスポンスモデルとサービス層の型可読性が向上し、レビュー時の誤読を減らせる。
+- Open Questions:
+  - `file_id` / `directory_id` を `NewType` にするかは未対応（FastAPI パスパラメータとの整合を見ながら段階的に検討可能）。
+- Verification:
+  - `python app.py tests/resources/image_root >/tmp/app.log 2>&1 & pid=$!; sleep 2; curl -s -o /tmp/subdirs.json -w '%{http_code}' http://localhost:8000/api/subdirectories; code=$?; kill $pid; wait $pid 2>/dev/null; echo " curl_exit=$code"; cat /tmp/subdirs.json; echo; tail -n 5 /tmp/app.log` -> 成功（HTTP 200）。
+  - `pytest -q tests/api/test_api_contract.py` -> 失敗（`httpx` 未導入の環境要因）。


### PR DESCRIPTION
### Motivation
- Make semantic differences between string fields in API models explicit so their intent is clear during review and IDE-assisted development.
- Allow early validation of file/directory name inputs (rejecting path separators and empty names) at the Pydantic model level.
- Reduce accidental mixing of identifiers, names, and file-name strings across service and route signatures.

### Description
- Add `app/models/types.py` which defines `DirectoryId`, `FileId`, `FileName`, and `DirectoryName`, with `FileName`/`DirectoryName` using `Annotated[str, StringConstraints(...)]` to forbid path separators and enforce minimum length.
- Replace raw `str` annotations in `app/models/schemas.py` with the new semantic aliases and change `DeleteImageResponse.deleted` from `str` to `FileName`.
- Update `app/api/routes.py` and `app/services/image_service.py` to follow the model-level aliases in function signatures (`DirectoryId`, `FileId`, `DirectoryName`) so types convey intent across layers.
- Add a task handoff log at `docs/agent-handoff/tasks/2026-02-22-api-string-field-type-aliases.md` describing changes, decisions, and open questions.

### Testing
- Ran `python -m compileall app` which compiled the updated modules successfully.
- Launched the app and verified the subdirectories endpoint with: `python app.py tests/resources/image_root` then `curl http://localhost:8000/api/subdirectories`, which returned HTTP `200` and the expected JSON.
- Ran `pytest -q tests/api/test_api_contract.py`, which failed in this environment due to the missing test dependency `httpx` (environmental failure, not a code runtime error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6c782fc0832bbeefc801299a9952)