### PR TITLE
docs: enforce E2E prerequisite setup for Codex agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@
   - 画面変更あり: ブラウザで表示確認（必要ならスクリーンショット）
   - API/ロジック変更あり: 再現手順と期待値を明文化
   - 文書変更のみ: 記載内容の整合性（コマンド・パス・URL）
+- E2E（`tests/e2e`）を実行する場合は、**必ず事前に**次を実行してから `pytest` を実行する。
+  ```sh
+  python -m pip install -r requirements-dev.txt
+  python -m playwright install --with-deps chromium
+  ```
+  - その後に実行: `pytest tests/e2e -q`
+  - 依存導入前に E2E を実行して skip / fail した場合は、導入後に再実行した結果を検証ログへ残す。
 - テスト失敗時は「失敗そのもの」よりも「再現条件」と「切り分け状況」を記録する。
 
 ## 9. 変更禁止・注意事項

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## テストセットアップ（開発・E2E共通）
+開発用テストを実行する前に、まず開発依存を導入してください。
+
+```sh
+python -m pip install -r requirements-dev.txt
+```
+
+### E2Eテスト（Playwright）
+`tests/e2e` では Playwright の Chromium 実体とOS依存ライブラリが必要です。
+E2Eを実行する際は、以下をこの順で実行します。
+
+```sh
+python -m pip install -r requirements-dev.txt
+python -m playwright install --with-deps chromium
+pytest tests/e2e -q
+```
+
+`python -m playwright install --with-deps chromium` を省略すると、環境によっては E2E が skip / fail します。
+
 ## 起動方法
 ```sh
 python app.py /path/to/image-dir

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,6 +98,14 @@ npm run build:bundle
 依存関係を未インストールの状態で `pytest` を実行すると失敗するため、先に開発用依存を導入してください。
 
 ```sh
-pip install -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 pytest -q
+```
+
+E2E（`tests/e2e`）を実行する場合は、ブラウザ実体を先に導入してください。
+
+```sh
+python -m pip install -r requirements-dev.txt
+python -m playwright install --with-deps chromium
+pytest tests/e2e -q
 ```

--- a/docs/agent-handoff/tasks/2026-02-22-e2e-setup-docs.md
+++ b/docs/agent-handoff/tasks/2026-02-22-e2e-setup-docs.md
@@ -1,0 +1,21 @@
+## Context Handoff
+- Goal:
+  - エージェントが E2E 実行前に必須セットアップ（dev依存 + Playwright Chromium）を行うよう、恒久ドキュメントを明確化する。
+- Changes:
+  - `AGENTS.md` のテスト観点に、`tests/e2e` 実行前の必須手順として
+    - `python -m pip install -r requirements-dev.txt`
+    - `python -m playwright install --with-deps chromium`
+    - `pytest tests/e2e -q`
+    を追加。
+  - `README.md` に「テストセットアップ（開発・E2E共通）」と「E2Eテスト（Playwright）」節を追加し、実行順を明記。
+  - `docs/ARCHITECTURE.md` のテストコマンドを `python -m pip` 表記へ統一し、E2E専用の事前セットアップ手順を追記。
+- Decisions:
+  - Decision: E2E 前提条件を `AGENTS.md`（エージェント規約）と `README.md`/`docs/ARCHITECTURE.md`（恒久運用情報）の両方に記載。
+  - Rationale: 「実行ルール」と「セットアップ手順」を別文脈でも参照できるようにし、見落としを減らすため。
+  - Impact: 依存未導入での E2E skip/fail を事前に抑止しやすくなる。
+- Open Questions:
+  - CI 以外のローカル環境で `--with-deps` 実行に sudo 相当権限が必要な場合のガイドは追加余地あり。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt`（成功）
+  - `python -m playwright install --with-deps chromium`（成功）
+  - `pytest tests/e2e -q`（成功: 1 passed）


### PR DESCRIPTION
### Motivation

- Agents were running E2E tests without installing development dependencies or Playwright browsers, causing skipped/failed runs that went unnoticed until CI. 
- Make the required setup explicit in agent-facing and repository docs so automated agents and humans follow the same steps before executing `tests/e2e`.

### Description

- Added an explicit E2E prerequisite block to `AGENTS.md` instructing agents to run `python -m pip install -r requirements-dev.txt` and `python -m playwright install --with-deps chromium` before `pytest tests/e2e -q`.
- Inserted a `Test setup` and `E2E test (Playwright)` section into `README.md` describing the exact command order for local and automated runs.
- Updated `docs/ARCHITECTURE.md` to use `python -m pip` and to document the Playwright browser install for E2E runs.
- Added a handoff log file at `docs/agent-handoff/tasks/2026-02-22-e2e-setup-docs.md` recording the change rationale, decisions, and verification results.

### Testing

- Ran `python -m pip install -r requirements-dev.txt` successfully to install `httpx`, `playwright`, and other dev deps.
- Ran `python -m playwright install --with-deps chromium` successfully, installing Chromium and required OS libraries.
- Ran `pytest tests/e2e -q` and observed `1 passed`, confirming the documented setup enables the E2E test to run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b01042f04832b870811ffa31b257b)