### PR TITLE
docs: add browser tool failure triage template

### DIFF
--- a/docs/agent-handoff/README.md
+++ b/docs/agent-handoff/README.md
@@ -20,3 +20,24 @@
 2. 同一タスクでは追記のみで更新し、既存セクションを上書きしない。
 3. 完了時に、恒久化が必要な内容だけを該当ディレクトリ `README.md` へ反映する。
 4. タスク完了後、必要に応じて `archive/` へ移動する。
+
+## browser tool 失敗時の記録テンプレート
+
+browser tool（Playwright）で画面確認に失敗した場合は、タスクログに次のテンプレートをそのまま記録する。
+
+```md
+## Browser Tool Failure Triage
+- Server bind / port: （例: `0.0.0.0:8000`）
+- browser tool `ports_to_forward`: 
+- `page.goto` URL: 
+- `wait_for_selector` target / timeout: 
+- `page.url` final value: 
+- `page.title`: 
+- `page.content()` 先頭（数百文字）: 
+- Parallel curl result: `curl http://127.0.0.1:8000/api/subdirectories`
+  - stdout:
+  - stderr:
+  - exit code:
+```
+
+この記録により、「サーバ死活は正常だがブラウザ到達に失敗」なのか「UIレンダリング待機不足（遅延）」なのかを切り分けやすくする。

--- a/docs/agent-handoff/tasks/2026-02-22-browser-tool-failure-template.md
+++ b/docs/agent-handoff/tasks/2026-02-22-browser-tool-failure-template.md
@@ -1,0 +1,13 @@
+## Context Handoff
+- Goal: `docs/agent-handoff/README.md` と `docs/agent-handoff/tasks/README.md` に browser tool 失敗時の記録テンプレートを追加する。
+- Changes:
+  - `docs/agent-handoff/README.md` に「browser tool 失敗時の記録テンプレート」節を追加。
+  - `docs/agent-handoff/tasks/README.md` に「browser tool 失敗時の追記テンプレート」節を追加。
+- Decisions:
+  - Decision: 両READMEに同一フォーマットのテンプレートを掲載。
+  - Rationale: タスク運用ルール側とタスク実体側のどちらを先に読む場合でも、同じ切り分け情報を記録できるようにするため。
+  - Impact: browser tool 失敗時の再現性と切り分け速度が向上。
+- Open Questions:
+  - なし。
+- Verification:
+  - `git diff -- docs/agent-handoff/README.md docs/agent-handoff/tasks/README.md docs/agent-handoff/tasks/2026-02-22-browser-tool-failure-template.md` で差分確認。

--- a/docs/agent-handoff/tasks/README.md
+++ b/docs/agent-handoff/tasks/README.md
@@ -5,3 +5,24 @@
 命名規則: `YYYY-MM-DD-<topic>.md`
 
 例: `2026-02-15-agent-handoff-policy.md`
+
+## browser tool 失敗時の追記テンプレート
+
+browser tool によるスクリーンショット取得や画面到達が失敗したときは、各タスクファイルへ以下を追記する。
+
+```md
+## Browser Tool Failure Triage
+- Server bind / port: （例: `0.0.0.0:8000`）
+- browser tool `ports_to_forward`: 
+- `page.goto` URL: 
+- `wait_for_selector` target / timeout: 
+- `page.url` final value: 
+- `page.title`: 
+- `page.content()` 先頭（数百文字）: 
+- Parallel curl result: `curl http://127.0.0.1:8000/api/subdirectories`
+  - stdout:
+  - stderr:
+  - exit code:
+```
+
+この情報セットを残すことで、ネットワーク到達性の問題とUI描画待機の問題を分離して判断できる。


### PR DESCRIPTION
### Motivation
- Provide a standardized template for recording Playwright / browser tool failures so engineers can quickly distinguish server reachability issues from UI rendering/wait-time problems.

### Description
- Add a `Browser Tool Failure Triage` template to `docs/agent-handoff/README.md` and `docs/agent-handoff/tasks/README.md` and create `docs/agent-handoff/tasks/2026-02-22-browser-tool-failure-template.md` with the task handoff summary.

### Testing
- Verified the new sections and file were added and consistent via repository checks; this is a documentation-only change so no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0a801d24832b82d59f16aa2dd82f)