### PR TITLE
docs: add minimal Codex screenshot playbook and handoff task

### DIFF
--- a/docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md
+++ b/docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md
@@ -1,0 +1,13 @@
+## Context Handoff
+- Goal:
+  - `docs/` 配下に、Codex 実行時の最小スクリーンショット手順テンプレートを追加する。
+- Changes:
+  - `docs/screenshot-playbook.md` を新規作成し、前提条件、`run_playwright_script` 例、`Not Found` 時のデバッグ手順、相対パス保存ルールを記載。
+- Decisions:
+  - Decision: 実行URLは `http://127.0.0.1:8000/` を明示。
+  - Rationale: Codex 実行環境で `localhost` 解決差異が起きるケースの切り分けを容易にするため。
+  - Impact: スクリーンショット取得手順の再現性向上、トラブル時の初動を標準化。
+- Open Questions:
+  - `run_playwright_script` の運用例を README にも重複掲示するかは未決定。
+- Verification:
+  - `sed -n '1,220p' docs/screenshot-playbook.md` で記載内容を確認（成功）。

--- a/docs/screenshot-playbook.md
+++ b/docs/screenshot-playbook.md
@@ -1,0 +1,38 @@
+# Codexスクリーンショット最小テンプレート
+
+## 前提
+- アプリサーバーが `0.0.0.0:8000` で起動済みであること。
+- 例: `python app.py tests/resources/image_root --host 0.0.0.0 --port 8000`
+
+## `run_playwright_script` 呼び出し例
+
+```json
+{
+  "ports_to_forward": [8000],
+  "script": "from playwright.sync_api import sync_playwright\n\nwith sync_playwright() as p:\n    browser = p.chromium.launch()\n    page = browser.new_page()\n\n    page.goto('http://127.0.0.1:8000/')\n    page.wait_for_selector('#subdir-list .subdir-card')\n\n    # 必要操作（例: 先頭サブディレクトリをクリック）\n    page.locator('#subdir-list .subdir-card').first.click()\n\n    page.screenshot(path='artifacts/home.png', full_page=True)\n    browser.close()"
+}
+```
+
+## 画面が `Not Found` のときのデバッグ手順
+
+`Not Found` が表示された場合は、`page.content()` と `page.url` を保存して原因を切り分ける。
+
+```python
+html = page.content()
+current_url = page.url
+
+with open('artifacts/not-found.html', 'w', encoding='utf-8') as f:
+    f.write(html)
+
+with open('artifacts/not-found-url.txt', 'w', encoding='utf-8') as f:
+    f.write(current_url + '\n')
+```
+
+- 保存したHTMLにアプリの要素（`#subdir-list` など）があるか確認する。
+- URLが想定どおり `http://127.0.0.1:8000/` か確認する。
+- API疎通確認として `http://127.0.0.1:8000/api/subdirectories` のステータスも別途確認する。
+
+## 画像保存先ルール
+- スクリーンショットやデバッグ出力は、必ず相対パスで保存する。
+- 例: `artifacts/home.png`（推奨）
+- 絶対パス（例: `/tmp/home.png`）は使わない。


### PR DESCRIPTION
### Motivation
- Provide a minimal, reproducible template for taking UI screenshots from Codex/Playwright runs so runs are consistent across environments.
- Make debugging easier when the browser tool sees a `Not Found` page by prescribing steps to capture the page HTML and URL for offline inspection.
- Enforce artifact path hygiene by requiring relative paths for screenshots to avoid environment-dependent absolute paths.
- Record the rationale and verification steps in the agent-handoff tasks to preserve context for future agents.

### Description
- Add `docs/screenshot-playbook.md` with a prerequisite that the app server is running on `0.0.0.0:8000` and an example `run_playwright_script` payload using `ports_to_forward: [8000]`.
- Document a minimal Playwright flow that uses `page.goto('http://127.0.0.1:8000/')`, `page.wait_for_selector('#subdir-list .subdir-card')`, a UI action (e.g. clicking the first subdir card), and `page.screenshot(path='artifacts/home.png')`.
- Include a debug snippet that saves `page.content()` and `page.url` to `artifacts/not-found.html` and `artifacts/not-found-url.txt` when `Not Found` is encountered.
- Add a task handoff file at `docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md` that records goal, changes, decisions, open questions, and verification steps.

### Testing
- Validated the new `docs/screenshot-playbook.md` content with `sed -n '1,220p' docs/screenshot-playbook.md`, which showed the expected sections and examples (success).
- Confirmed the new documentation and handoff files are present in the working tree (success).
- No automated E2E tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0b973b54832bbe470ac678dd273c)