### PR TITLE
ci: skip CI jobs for docs PR titles

### DIFF
--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   frontend-build:
+    if: github.event_name == 'push' || !startsWith(github.event.pull_request.title, 'docs:')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,6 +55,7 @@ jobs:
         run: git diff --exit-code -- static/home-app
 
   ui-e2e:
+    if: github.event_name == 'push' || !startsWith(github.event.pull_request.title, 'docs:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/agent-handoff/tasks/2026-02-22-ci-skip-docs-pr-title.md
+++ b/docs/agent-handoff/tasks/2026-02-22-ci-skip-docs-pr-title.md
@@ -1,0 +1,19 @@
+## Context Handoff
+- Goal: PRタイトルが `docs:` で始まる場合など、CI実行が不要なケースで GitHub Actions のジョブを起動しないようにする。
+- Changes:
+  - `.github/workflows/ui-build.yml` の `frontend-build` と `ui-e2e` に job-level `if` 条件を追加。
+  - `pull_request` イベントかつ PRタイトルが `docs:` で始まる場合は2ジョブとも skip し、`push`（main）時は従来通り実行。
+- Decisions:
+  - Decision: ワークフロートリガー自体ではなく、各ジョブに `if` を追加してスキップ制御を実装。
+  - Rationale: `on.pull_request` では PRタイトルに基づく条件分岐ができないため、job-level の式評価が最小差分で安全。
+  - Impact: docs系PRではCI実行時間を削減し、通常PR/`main` pushの検証動線は維持。
+- Open Questions:
+  - `docs:` 以外のprefix（例: `chore(docs):`）もスキップ対象に含めるかは未決。
+- Verification:
+  - `python -m yaml.safe_load(open('.github/workflows/ui-build.yml'))`（成功: YAML構文エラーなし）
+
+## Context Handoff (追記)
+- Verification:
+  - `python - <<'PY' ... import yaml ... PY` は `ModuleNotFoundError: No module named 'yaml'` で失敗（環境にPyYAML未導入）。
+  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ui-build.yml'); puts 'ok'"` で代替検証し成功。
+- Note: 上記13行目の記載は誤り。`python -m yaml.safe_load(...)` はコマンドとして不正で、実検証にはRubyコマンド結果を採用。


### PR DESCRIPTION
### Motivation
- Reduce wasted CI compute by skipping heavy jobs for pull requests whose title indicates only documentation changes (PR titles starting with `docs:`). 
- Preserve existing verification for `push` to `main` and for non-docs PRs to avoid introducing risk to release workflows.

### Description
- Add job-level `if` conditions to `frontend-build` and `ui-e2e` in `.github/workflows/ui-build.yml` so each job runs only when `github.event_name == 'push'` or the pull request title does not start with `docs:`. 
- Add a task handoff log at `docs/agent-handoff/tasks/2026-02-22-ci-skip-docs-pr-title.md` recording goal, changes, decisions, open questions, and verification notes.

### Testing
- Verified the workflow YAML is parseable with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ui-build.yml'); puts 'ok'"`, which succeeded. 
- Attempted to validate with a Python snippet using `yaml.safe_load` but it failed due to missing `PyYAML` in the environment (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0c1fe8b0832b8f5d22a77760bce0)