### PR TITLE
docs: clarify Codex screenshot Not Found workaround steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,24 @@ Codex の browser tool（Playwright 実行環境）では、`localhost` の解�
 
 回避策:
 
-1. まずシェル側でアプリが正常起動していることを確認する。
+1. シェル側で次の固定コマンドを使ってアプリを起動し、HTTP 応答を確認する。
 
 ```sh
-python app.py tests/resources/image_root
-curl -i http://localhost:8000/
-curl -i http://localhost:8000/api/subdirectories
+python app.py tests/resources/image_root --host 0.0.0.0 --port 8000
+curl -i http://127.0.0.1:8000/
+curl -i http://127.0.0.1:8000/api/subdirectories
 ```
 
-2. browser tool でスクリーンショットを取る前に、`/api/subdirectories` の HTTP ステータスが 200 か確認する。
-3. browser tool 側で `localhost` が到達不能な場合は、スクリーンショット運用を行わず、
-   代替として `curl` の結果（HTTP 200 と JSON 応答）を確認証跡として扱う。
-4. 起動引数のパスを必ず `tests/resources/image_root`（`_`）にする（`image-root` は誤り）。
+2. browser tool 実行時は `run_playwright_script` の `ports_to_forward: [8000]` を必須にする。
+3. `page.goto` は `http://127.0.0.1:8000/` を優先し、`localhost` は環境差で失敗し得るため常用しない。
+4. スクリーンショット前にアプリ固有セレクタの描画完了を待つ。
+   - 例: `await page.wait_for_selector('#subdir-list .subdir-card')`
+5. 失敗時は以下の順で切り分ける。
+   - `curl http://127.0.0.1:8000/api/subdirectories` が 200 / JSON 応答か確認
+   - browser 側の待機タイムアウトログ（`wait_for_selector` / `goto`）を確認
+   - `page.goto` の URL（`127.0.0.1` とパス末尾 `/`）を見直す
+6. browser tool 側で接続できない場合は、スクリーンショット運用を中止し、`curl` 結果を確認証跡として残す。
+7. 起動引数のパスを必ず `tests/resources/image_root`（`_`）にする（`image-root` は誤り）。
 
 
 ## フロントエンド（React + TypeScript + Vite）

--- a/docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md
+++ b/docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md
@@ -11,3 +11,19 @@
   - `run_playwright_script` の運用例を README にも重複掲示するかは未決定。
 - Verification:
   - `sed -n '1,220p' docs/screenshot-playbook.md` で記載内容を確認（成功）。
+
+## Context Handoff
+- Goal:
+  - `README.md` の「Codex環境でスクリーンショットが Not Found になる場合の回避策」を、Codex browser tool 前提の手順に更新する。
+- Changes:
+  - サーバ起動コマンドを `python app.py tests/resources/image_root --host 0.0.0.0 --port 8000` の固定例へ更新。
+  - `run_playwright_script` 実行時の `ports_to_forward: [8000]` 必須化、`page.goto` の `http://127.0.0.1:8000/` 優先、`#subdir-list .subdir-card` 待機手順を追記。
+  - 失敗時の切り分け順を `curl /api/subdirectories` → browser 側タイムアウトログ確認 → URL 見直しの順で箇条書き追加。
+- Decisions:
+  - Decision: README の回避策を「接続先URL・ポート転送・セレクタ待機」の3点セットで明文化。
+  - Rationale: Not Found/タイムアウトの再発を、実行順序の標準化で減らすため。
+  - Impact: Codex browser tool を使うスクリーンショット手順の再現性が向上。
+- Open Questions:
+  - なし。
+- Verification:
+  - `sed -n '71,125p' README.md` で追記内容を確認（成功）。


### PR DESCRIPTION
### Motivation
- The Codex browser tool (Playwright) can resolve `localhost` differently than the shell environment, causing `Not Found` when taking screenshots; the README needs a clear, reproducible playbook to avoid these failures.
- The goal is to standardize startup, port forwarding and browser-side waiting so screenshot runs are reliable across environments.

### Description
- Updated the README section "Codex環境でスクリーンショットが `Not Found` になる場合の回避策" to show a fixed startup example using `python app.py tests/resources/image_root --host 0.0.0.0 --port 8000` and curl checks against `http://127.0.0.1:8000`.
- Documented that `run_playwright_script` must include `ports_to_forward: [8000]`, recommended using `page.goto('http://127.0.0.1:8000/')` instead of `localhost`, and added an example to wait for an app-specific selector like `await page.wait_for_selector('#subdir-list .subdir-card')` before taking screenshots.
- Added a concise failure triage order to the README and appended a task-specific context handoff entry under `docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md` describing the change and rationale.

### Testing
- Verified the README changes with `sed -n '71,130p' README.md` and `nl -ba README.md | sed -n '71,130p'`, which showed the new startup, port-forward and selector-wait instructions (success).
- Verified the task handoff append with `tail -n 40 docs/agent-handoff/tasks/2026-02-22-codex-screenshot-playbook.md`, which showed the new context and verification notes (success).
- Performed repository file checks with `rg --files` and `git status --short` to confirm the modified files are present in the working tree (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0d4ea358832bb1668f8d98db6086)