### PR TITLE
feat: add prompt tag indexing service with API refresh/query

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -13,6 +13,9 @@ from app.models.schemas import (
     RenameDirectoryRequest,
     RenameDirectoryResponse,
     SubdirectoriesResponse,
+    TagIndexRefreshResponse,
+    TagQueryRequest,
+    TagQueryResponse,
 )
 from app.models.types import DirectoryId, FileId
 from app.services.image_service import (
@@ -23,9 +26,10 @@ from app.services.image_service import (
     UnsupportedMediaTypeError,
     ValidationError,
 )
+from app.services.tag_index_service import TagIndexService
 
 
-def create_api_router(service: ImageService) -> APIRouter:
+def create_api_router(service: ImageService, tag_index_service: TagIndexService) -> APIRouter:
     router = APIRouter(prefix="/api")
 
     @router.get("/subdirectories", response_model=SubdirectoriesResponse)
@@ -121,5 +125,19 @@ def create_api_router(service: ImageService) -> APIRouter:
             renamed_from=renamed_from,
             renamed_to=renamed_to,
         )
+
+
+    @router.post("/tag-index/refresh", response_model=TagIndexRefreshResponse)
+    def refresh_tag_index() -> TagIndexRefreshResponse:
+        tag_index_service.refresh_index()
+        return TagIndexRefreshResponse(
+            indexed_files=len(tag_index_service.file_id_to_tags),
+            indexed_tags=len(tag_index_service.tag_to_file_ids),
+        )
+
+    @router.post("/tag-index/query", response_model=TagQueryResponse)
+    def query_tag_index(payload: TagQueryRequest) -> TagQueryResponse:
+        file_ids = tag_index_service.query(payload.tags, payload.mode)
+        return TagQueryResponse(file_ids=file_ids, total=len(file_ids))
 
     return router

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.api.routes import create_api_router
 from app.config import AppSettings
 from app.repositories.filesystem import FileSystemRepository
 from app.services.image_service import ImageService, ResourceRegistry
+from app.services.tag_index_service import TagIndexService
 
 DEFAULT_STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 
@@ -21,8 +22,10 @@ def create_app(settings: AppSettings) -> FastAPI:
     repository = FileSystemRepository()
     registry = ResourceRegistry()
     service = ImageService(base_dir=settings.base_dir, repository=repository, registry=registry)
+    tag_index_service = TagIndexService(base_dir=settings.base_dir, repository=repository, registry=registry)
+    tag_index_service.build_index(settings.base_dir)
 
-    app.include_router(create_api_router(service))
+    app.include_router(create_api_router(service, tag_index_service))
 
     @app.get("/")
     def home() -> FileResponse:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel
+from typing import Literal
 
 from app.models.types import DirectoryId, DirectoryName, FileId, FileName
 
@@ -38,3 +39,18 @@ class RenameDirectoryResponse(BaseModel):
     directory_id: DirectoryId
     renamed_from: DirectoryName
     renamed_to: DirectoryName
+
+
+class TagIndexRefreshResponse(BaseModel):
+    indexed_files: int
+    indexed_tags: int
+
+
+class TagQueryRequest(BaseModel):
+    tags: list[str]
+    mode: Literal["and", "or"] = "or"
+
+
+class TagQueryResponse(BaseModel):
+    file_ids: list[FileId]
+    total: int

--- a/app/repositories/filesystem.py
+++ b/app/repositories/filesystem.py
@@ -16,6 +16,13 @@ class FileSystemRepository:
             if entry.is_file() and entry.suffix.lower() in self.IMAGE_EXTENSIONS
         ]
 
+    def list_images_recursive(self, base_dir: Path) -> list[Path]:
+        return [
+            entry
+            for entry in sorted(base_dir.rglob("*"))
+            if entry.is_file() and entry.suffix.lower() in self.IMAGE_EXTENSIONS
+        ]
+
     def delete_file(self, path: Path) -> None:
         path.unlink()
 

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -79,36 +80,52 @@ class TagIndexService:
         tag_to_file_ids: dict[str, set[FileId]] = {}
         file_id_to_tags: dict[FileId, list[str]] = {}
         file_metadata: dict[FileId, IndexedFileMeta] = {}
+        total = len(image_paths)
+
+        self._print_progress(current=0, total=total)
 
         with self._connect() as conn:
             conn.execute("DELETE FROM file_tags")
             conn.execute("DELETE FROM indexed_files")
 
-            for image_path in image_paths:
+            for index, image_path in enumerate(image_paths, start=1):
                 prompt_result = extract_generation_prompts(image_path)
                 positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
-                if not positive_tags:
-                    continue
+                if positive_tags:
+                    file_id = FileId(self.registry.register(image_path))
+                    stat_result = image_path.stat()
+                    fingerprint = FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size)
 
-                file_id = FileId(self.registry.register(image_path))
-                stat_result = image_path.stat()
-                fingerprint = FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size)
+                    file_id_to_tags[file_id] = positive_tags
+                    file_metadata[file_id] = IndexedFileMeta(path=str(image_path.resolve()), fingerprint=fingerprint)
 
-                file_id_to_tags[file_id] = positive_tags
-                file_metadata[file_id] = IndexedFileMeta(path=str(image_path.resolve()), fingerprint=fingerprint)
+                    conn.execute(
+                        "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                        (file_id, str(image_path.resolve()), fingerprint.mtime_ns, fingerprint.size),
+                    )
 
-                conn.execute(
-                    "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
-                    (file_id, str(image_path.resolve()), fingerprint.mtime_ns, fingerprint.size),
-                )
+                    for tag in positive_tags:
+                        tag_to_file_ids.setdefault(tag, set()).add(file_id)
+                        conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
 
-                for tag in positive_tags:
-                    tag_to_file_ids.setdefault(tag, set()).add(file_id)
-                    conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
+                self._print_progress(current=index, total=total)
 
         self.tag_to_file_ids = tag_to_file_ids
         self.file_id_to_tags = file_id_to_tags
         self.file_metadata = file_metadata
+
+    def _print_progress(self, *, current: int, total: int) -> None:
+        if total == 0:
+            message = "[tag-index] build progress: 0/0 (100%)"
+        else:
+            percent = int((current / total) * 100)
+            bar_width = 20
+            filled = int(bar_width * current / total)
+            bar = "#" * filled + "-" * (bar_width - filled)
+            message = f"[tag-index] build progress: [{bar}] {current}/{total} ({percent}%)"
+
+        end = "\n" if current >= total else "\r"
+        print(message, file=sys.stdout, end=end, flush=True)
 
     def refresh_index(self) -> None:
         # NOTE: Full rebuild for now. `file_metadata` stores mtime/size fingerprints

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.models.types import FileId
+from app.repositories.filesystem import FileSystemRepository
+from app.services.image_service import ResourceRegistry
+from app.services.prompt_extractor import extract_generation_prompts
+
+QueryMode = Literal["and", "or"]
+
+
+@dataclass(frozen=True)
+class FileFingerprint:
+    mtime_ns: int
+    size: int
+
+
+@dataclass(frozen=True)
+class IndexedFileMeta:
+    path: str
+    fingerprint: FileFingerprint
+
+
+class TagIndexService:
+    def __init__(
+        self,
+        *,
+        base_dir: Path,
+        repository: FileSystemRepository,
+        registry: ResourceRegistry,
+        db_path: Path = Path("tag_index.sqlite3"),
+    ) -> None:
+        self.base_dir = base_dir
+        self.repository = repository
+        self.registry = registry
+        self.db_path = db_path
+
+        self.tag_to_file_ids: dict[str, set[FileId]] = {}
+        self.file_id_to_tags: dict[FileId, list[str]] = {}
+        self.file_metadata: dict[FileId, IndexedFileMeta] = {}
+
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS indexed_files (
+                    file_id TEXT PRIMARY KEY,
+                    path TEXT NOT NULL UNIQUE,
+                    mtime_ns INTEGER NOT NULL,
+                    size INTEGER NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS file_tags (
+                    tag TEXT NOT NULL,
+                    file_id TEXT NOT NULL,
+                    PRIMARY KEY (tag, file_id),
+                    FOREIGN KEY (file_id) REFERENCES indexed_files(file_id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_file_tags_file_id ON file_tags(file_id);
+                """
+            )
+
+    def build_index(self, base_dir: Path | None = None) -> None:
+        target_base = (base_dir or self.base_dir).resolve()
+        image_paths = self.repository.list_images_recursive(target_base)
+
+        tag_to_file_ids: dict[str, set[FileId]] = {}
+        file_id_to_tags: dict[FileId, list[str]] = {}
+        file_metadata: dict[FileId, IndexedFileMeta] = {}
+
+        with self._connect() as conn:
+            conn.execute("DELETE FROM file_tags")
+            conn.execute("DELETE FROM indexed_files")
+
+            for image_path in image_paths:
+                prompt_result = extract_generation_prompts(image_path)
+                positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
+                if not positive_tags:
+                    continue
+
+                file_id = FileId(self.registry.register(image_path))
+                stat_result = image_path.stat()
+                fingerprint = FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size)
+
+                file_id_to_tags[file_id] = positive_tags
+                file_metadata[file_id] = IndexedFileMeta(path=str(image_path.resolve()), fingerprint=fingerprint)
+
+                conn.execute(
+                    "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                    (file_id, str(image_path.resolve()), fingerprint.mtime_ns, fingerprint.size),
+                )
+
+                for tag in positive_tags:
+                    tag_to_file_ids.setdefault(tag, set()).add(file_id)
+                    conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
+
+        self.tag_to_file_ids = tag_to_file_ids
+        self.file_id_to_tags = file_id_to_tags
+        self.file_metadata = file_metadata
+
+    def refresh_index(self) -> None:
+        # NOTE: Full rebuild for now. `file_metadata` stores mtime/size fingerprints
+        # that enable future diff-based refreshes.
+        self.build_index(self.base_dir)
+
+    def query(self, tags: list[str], mode: QueryMode) -> list[FileId]:
+        normalized_tags = _normalize_tags(tags)
+        if not normalized_tags:
+            return []
+
+        matched_sets = [self.tag_to_file_ids.get(tag, set()) for tag in normalized_tags]
+        if not matched_sets:
+            return []
+
+        if mode == "and":
+            matched = set.intersection(*matched_sets) if matched_sets else set()
+        else:
+            matched = set.union(*matched_sets)
+
+        return sorted(matched)
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_tag in tags:
+        tag = raw_tag.strip().casefold()
+        if not tag or tag in seen:
+            continue
+        seen.add(tag)
+        normalized.append(tag)
+    return normalized

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -17,3 +17,18 @@
   - `python -m playwright install --with-deps chromium` : 成功
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py tests/services/test_prompt_extractor.py -q` : 成功（10 passed）
   - `PYTHONPATH=. pytest -q` : 成功（11 passed）
+
+## Context Handoff
+- Goal: インデクス構築中の進捗をローカルコンソールで可視化する。
+- Changes:
+  - `app/services/tag_index_service.py` に進捗表示処理 `_print_progress` を追加し、`build_index` の開始時・各ファイル処理後にプログレスバーを標準出力へ出力。
+  - `tests/services/test_tag_index_service.py` に進捗バー出力確認テストを追加。
+- Decisions:
+  - Decision: 外部依存（tqdm等）は追加せず、標準出力へのキャリッジリターン更新でプログレスバーを実装。
+  - Rationale: 依存を増やさず、既存起動フローに最小差分で要件を満たすため。
+  - Impact: インデクス構築時にローカルコンソールで進行率を確認可能になった。
+- Open Questions:
+  - 大規模件数時に出力頻度を間引くか（現在は各ファイルで更新）。
+- Verification:
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 成功
+  - `PYTHONPATH=. pytest -q` : 成功

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -1,0 +1,19 @@
+## Context Handoff
+- Goal: 画像生成プロンプトのポジティブ語句をタグ化し、再帰収集・インデクス再構築・AND/OR検索を `/api` から利用可能にする。
+- Changes:
+  - `app/services/tag_index_service.py` を新規追加し、`build_index` / `refresh_index` / `query` を実装。SQLite 永続化（`tag_index.sqlite3`）と `tag -> set[file_id]`, `file_id -> tags[]` のメモリインデクスを保持。
+  - `app/repositories/filesystem.py` に `list_images_recursive` を追加し、全サブディレクトリ配下の画像を取得。
+  - `app/main.py` で起動時にタグインデクスを初回構築、`app/api/routes.py` と `app/models/schemas.py` にタグ検索/リフレッシュAPIを追加。
+  - `tests/services/test_tag_index_service.py` と `tests/api/test_api_contract.py` / `tests/api/conftest.py` を更新し、検索とリフレッシュのAPI契約を検証。
+- Decisions:
+  - Decision: 初回実装では `refresh_index` を全件再構築にし、将来差分更新のため `FileFingerprint(mtime_ns, size)` と `file_metadata` 構造を先に導入。
+  - Rationale: 仕様充足と堅牢性を優先し、差分ロジックの複雑化を避けつつ移行パスを確保するため。
+  - Impact: 将来、`refresh_index` の内部実装を差分方式に置換してもAPI契約は維持できる。
+- Open Questions:
+  - 検索結果に `file_id` のみを返す現行仕様で十分か（将来的にタグハイライトやファイル名同梱要件が出る可能性）。
+  - タグ正規化（casefold）のみで十分か（全角半角・記号正規化の要否）。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `python -m playwright install --with-deps chromium` : 成功
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py tests/services/test_prompt_extractor.py -q` : 成功（10 passed）
+  - `PYTHONPATH=. pytest -q` : 成功（11 passed）

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -82,3 +82,15 @@ def api_client_factory(free_tcp_port_factory):
         if process.poll() is None:
             process.terminate()
             process.wait(timeout=3)
+
+
+@pytest.fixture
+def copied_prompt_image_root(tmp_path: Path) -> Path:
+    source = Path("tests/resources/images_with_prompt")
+    destination = tmp_path / "prompt_root"
+    destination.mkdir()
+    shutil.copy2(source / "00009.png", destination / "00009.png")
+    nested = destination / "nested"
+    nested.mkdir()
+    shutil.copy2(source / "00010.avif", nested / "00010.avif")
+    return destination

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -122,3 +122,22 @@ def test_put_subdirectory_rename_success_and_conflict(api_client_factory, copied
     names = [entry["name"] for entry in refreshed.json()["subdirectories"]]
     assert "renamed-dir" in names
     assert rename_target["name"] not in names
+
+
+def test_tag_index_query_and_refresh(api_client_factory, copied_prompt_image_root):
+    client = api_client_factory(copied_prompt_image_root)
+
+    query_response = client.post(
+        "/api/tag-index/query",
+        json={"tags": ["old male", "best quality"], "mode": "and"},
+    )
+    assert query_response.status_code == 200
+    data = query_response.json()
+    assert data["total"] == 2
+    assert len(data["file_ids"]) == 2
+
+    refresh_response = client.post("/api/tag-index/refresh")
+    assert refresh_response.status_code == 200
+    refreshed = refresh_response.json()
+    assert refreshed["indexed_files"] == 2
+    assert refreshed["indexed_tags"] >= 4

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from app.repositories.filesystem import FileSystemRepository
+from app.services.image_service import ResourceRegistry
+from app.services.tag_index_service import TagIndexService
+
+
+def test_build_index_and_query_with_and_or_modes(tmp_path: Path):
+    source = Path("tests/resources/images_with_prompt")
+    base_dir = tmp_path / "images"
+    nested_dir = base_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    shutil.copy2(source / "00009.png", nested_dir / "00009.png")
+    shutil.copy2(source / "00010.avif", base_dir / "00010.avif")
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+
+    service.build_index(base_dir)
+
+    assert "old male" in service.tag_to_file_ids
+    assert len(service.file_id_to_tags) == 2
+    assert len(service.query(["old male", "best quality"], "and")) == 2
+    assert len(service.query(["holding cat", "unknown"], "or")) == 2
+    assert service.query(["unknown"], "and") == []
+
+    service.refresh_index()
+    assert len(service.file_metadata) == 2

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -8,7 +8,7 @@ from app.services.image_service import ResourceRegistry
 from app.services.tag_index_service import TagIndexService
 
 
-def test_build_index_and_query_with_and_or_modes(tmp_path: Path):
+def test_build_index_and_query_with_and_or_modes(tmp_path: Path, capsys):
     source = Path("tests/resources/images_with_prompt")
     base_dir = tmp_path / "images"
     nested_dir = base_dir / "nested"
@@ -33,3 +33,24 @@ def test_build_index_and_query_with_and_or_modes(tmp_path: Path):
 
     service.refresh_index()
     assert len(service.file_metadata) == 2
+
+
+
+def test_build_index_outputs_progress_bar(tmp_path: Path, capsys):
+    source = Path("tests/resources/images_with_prompt")
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    shutil.copy2(source / "00009.png", base_dir / "00009.png")
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+
+    service.build_index(base_dir)
+    captured = capsys.readouterr()
+
+    assert "[tag-index] build progress:" in captured.out
+    assert "1/1 (100%)" in captured.out


### PR DESCRIPTION
### Motivation
- Enable tag-based search by extracting positive prompts from images using the existing prompt extractor. 
- Support indexing across all subdirectories (recursive scan) and persist the index for future use. 
- Provide a simple API to refresh the index and to query tags with AND/OR semantics. 

### Description
- Add `TagIndexService` (`app/services/tag_index_service.py`) implementing `build_index(base_dir)`, `refresh_index()`, and `query(tags, mode)` that: uses `extract_generation_prompts`, builds in-memory `tag -> set[file_id]` and `file_id -> tags[]` maps, records `FileFingerprint(mtime_ns, size)` in `file_metadata`, and persists `indexed_files` / `file_tags` to a SQLite DB (`tag_index.sqlite3`).
- Add recursive image listing `list_images_recursive` to `FileSystemRepository` (`app/repositories/filesystem.py`).
- Wire startup indexing in `create_app` by instantiating `TagIndexService` and calling `build_index`, and inject the service into the API router (`app/main.py`).
- Expose APIs `POST /api/tag-index/refresh` and `POST /api/tag-index/query` and add corresponding Pydantic schemas (`app/models/schemas.py`).
- Add unit tests for the service (`tests/services/test_tag_index_service.py`) and extend API contract tests to cover query & refresh (`tests/api/test_api_contract.py`) and a fixture for prompt images (`tests/api/conftest.py`).
- Add a task handoff document at `docs/agent-handoff/tasks/2026-02-28-tag-index-service.md` describing decisions and verification steps.

### Testing
- Installed dev deps with `python -m pip install -r requirements-dev.txt` and Playwright browsers via `python -m playwright install --with-deps chromium`, both succeeded. 
- Ran targeted tests with `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py tests/services/test_prompt_extractor.py -q` which passed (10 passed). 
- Ran the full test suite with `PYTHONPATH=. pytest -q`, which also passed (11 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a289b7f3b0832b8bb3f31102e65858)