### PR TITLE
feat: load tag index from SQLite on startup with fallback rebuild

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from pathlib import Path
 
 import uvicorn
@@ -23,7 +24,22 @@ def create_app(settings: AppSettings) -> FastAPI:
     registry = ResourceRegistry()
     service = ImageService(base_dir=settings.base_dir, repository=repository, registry=registry)
     tag_index_service = TagIndexService(base_dir=settings.base_dir, repository=repository, registry=registry)
-    tag_index_service.build_index(settings.base_dir)
+
+    loaded_count = 0
+    load_failed = False
+    try:
+        loaded_count = tag_index_service.load_index_from_db()
+    except sqlite3.Error:
+        load_failed = True
+
+    fallback_built = load_failed or loaded_count == 0
+    if fallback_built:
+        tag_index_service.build_index(settings.base_dir)
+
+    print(
+        f"[tag-index] startup load_count={loaded_count} "
+        f"fallback_build={fallback_built}"
+    )
 
     app.include_router(create_api_router(service, tag_index_service))
 

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -112,6 +112,32 @@ class TagIndexService:
         self.file_id_to_tags = file_id_to_tags
         self.file_metadata = file_metadata
 
+    def load_index_from_db(self) -> int:
+        tag_to_file_ids: dict[str, set[FileId]] = {}
+        file_id_to_tags: dict[FileId, list[str]] = {}
+        file_metadata: dict[FileId, IndexedFileMeta] = {}
+
+        with self._connect() as conn:
+            indexed_files = conn.execute("SELECT file_id, path, mtime_ns, size FROM indexed_files")
+            for file_id_raw, path, mtime_ns, size in indexed_files:
+                file_id = FileId(file_id_raw)
+                fingerprint = FileFingerprint(mtime_ns=mtime_ns, size=size)
+                file_metadata[file_id] = IndexedFileMeta(path=path, fingerprint=fingerprint)
+                file_id_to_tags[file_id] = []
+
+            file_tags = conn.execute("SELECT tag, file_id FROM file_tags")
+            for tag, file_id_raw in file_tags:
+                file_id = FileId(file_id_raw)
+                if file_id not in file_metadata:
+                    continue
+                file_id_to_tags[file_id].append(tag)
+                tag_to_file_ids.setdefault(tag, set()).add(file_id)
+
+        self.tag_to_file_ids = tag_to_file_ids
+        self.file_id_to_tags = file_id_to_tags
+        self.file_metadata = file_metadata
+        return len(file_metadata)
+
     def refresh_index(self) -> None:
         # NOTE: Full rebuild for now. `file_metadata` stores mtime/size fingerprints
         # that enable future diff-based refreshes.

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -48,3 +48,19 @@
 - Verification:
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 成功
   - `PYTHONPATH=. pytest -q` : 成功
+
+## Context Handoff
+- Goal: 起動時にDBからタグインデクスを復元し、空DBまたはロード失敗時のみフルビルドへフォールバックする。
+- Changes:
+  - `app/services/tag_index_service.py` に `load_index_from_db()` を追加し、`indexed_files`/`file_tags` から `tag_to_file_ids`・`file_id_to_tags`・`file_metadata` を再構築してロード件数を返すようにした。
+  - `app/main.py` の `create_app()` を変更し、起動時はDBロード→必要時のみ `build_index()` の順で実行、`load_count` と `fallback_build` を1行ログ出力するようにした。
+  - `tests/services/test_tag_index_service.py` に、DB保存後に別インスタンスでロード復元できるテストを追加した。
+  - `tests/api/test_api_contract.py` に、事前作成DBを起動時にロードして検索APIが機能する契約テスト（空ディレクトリ起動でフルビルド非前提）を追加した。
+- Decisions:
+  - Decision: DBロード結果の判定は「ロード件数（int）」で扱い、0件は成功扱いにしたうえで起動制御でフォールバック判定する。
+  - Rationale: 空DBをエラーと区別し、起動時の分岐を単純化するため。
+  - Impact: 既存DBがある環境では起動時の不要な全件再構築を回避できる。
+- Open Questions:
+  - DB破損時の詳細ログ（例: 例外種別）を追加で出すかどうか。
+- Verification:
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 成功

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.config import AppSettings
+from app.main import create_app
+from app.repositories.filesystem import FileSystemRepository
+from app.services.image_service import ResourceRegistry
+from app.services.tag_index_service import TagIndexService
+
 
 def _first_directory_id(client):
     response = client.get("/api/subdirectories")
@@ -141,3 +151,37 @@ def test_tag_index_query_and_refresh(api_client_factory, copied_prompt_image_roo
     refreshed = refresh_response.json()
     assert refreshed["indexed_files"] == 2
     assert refreshed["indexed_tags"] >= 4
+
+
+def test_tag_index_query_works_on_startup_by_loading_db_without_rebuild(tmp_path, monkeypatch):
+    static_dir = Path(__file__).resolve().parents[2] / "static"
+    source = Path("tests/resources/images_with_prompt")
+    indexed_dir = tmp_path / "indexed"
+    indexed_dir.mkdir()
+    (indexed_dir / "nested").mkdir()
+    (indexed_dir / "00009.png").write_bytes((source / "00009.png").read_bytes())
+    (indexed_dir / "nested" / "00010.avif").write_bytes((source / "00010.avif").read_bytes())
+
+    builder = TagIndexService(
+        base_dir=indexed_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+    builder.build_index(indexed_dir)
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    app = create_app(AppSettings.from_paths(base_dir=empty_dir, static_dir=static_dir))
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/tag-index/query",
+            json={"tags": ["old male", "best quality"], "mode": "and"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert len(payload["file_ids"]) == 2

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -54,3 +54,33 @@ def test_build_index_outputs_progress_bar(tmp_path: Path, capsys):
 
     assert "[tag-index] build" in captured.out
     assert "100%" in captured.out
+
+
+def test_load_index_from_db_restores_in_memory_state(tmp_path: Path):
+    source = Path("tests/resources/images_with_prompt")
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    shutil.copy2(source / "00009.png", base_dir / "00009.png")
+    shutil.copy2(source / "00010.avif", base_dir / "00010.avif")
+    db_path = tmp_path / "tag_index.sqlite3"
+
+    builder = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=db_path,
+    )
+    builder.build_index(base_dir)
+
+    loader = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=db_path,
+    )
+    loaded_count = loader.load_index_from_db()
+
+    assert loaded_count == 2
+    assert len(loader.file_id_to_tags) == 2
+    assert len(loader.file_metadata) == 2
+    assert len(loader.query(["old male", "best quality"], "and")) == 2


### PR DESCRIPTION
### Motivation
- Avoid unnecessary full index rebuilds at startup by restoring in-memory tag index state from the persistent SQLite DB when available.
- Ensure the app's tag-search API is usable immediately after startup even if the full build is not performed.

### Description
- Added `TagIndexService.load_index_from_db()` which reconstructs `tag_to_file_ids`, `file_id_to_tags`, and `file_metadata` from `indexed_files` and `file_tags` and returns the number of loaded files (0 is treated as a successful empty load). (`app/services/tag_index_service.py`)
- Changed `create_app()` to try `load_index_from_db()` first and run `build_index()` only when the DB load fails or returns 0, and emit a one-line startup log with `load_count` and `fallback_build` flags. (`app/main.py`)
- Added a unit test verifying that a saved DB can be loaded into a new service instance via `load_index_from_db()`. (`tests/services/test_tag_index_service.py`)
- Added an API contract test that pre-builds a DB, starts the app with an empty base dir, and verifies the tag-index query API works without requiring a full rebuild. (`tests/api/test_api_contract.py`) and updated task handoff notes. (`docs/agent-handoff/tasks/2026-02-28-tag-index-service.md`)

### Testing
- Installed dev deps and replayed test workflow: `python -m pip install -r requirements-dev.txt` and `python -m playwright install --with-deps chromium` which completed successfully. 
- Ran focused tests: `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` which passed. 
- Ran full test suite: `PYTHONPATH=. pytest -q` after installing Playwright browsers, and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c67a20b8832b8dbe7d76509bf0c9)