### PR TITLE
Expand metadata test patterns for prompt extraction and tag index

### DIFF
--- a/docs/agent-handoff/tasks/2026-02-28-metadata-test-patterns.md
+++ b/docs/agent-handoff/tasks/2026-02-28-metadata-test-patterns.md
@@ -1,0 +1,19 @@
+## Context Handoff
+- Goal: メタデータ入りテスト画像（00009/00010/00025/00027/00029）のバリエーションをテストで網羅し、回帰検知を強化する。
+- Changes:
+  - `tests/services/test_prompt_extractor.py` をパラメータ化し、5種類の画像それぞれで positive/negative prompt 抽出結果を検証。
+  - `tests/services/test_tag_index_service.py` のインデックス対象を5画像に拡張し、`solo` や `knight` を含むクエリ条件を追加。
+  - `tests/api/conftest.py` の `copied_prompt_image_root` fixture を `tests/resources/images_with_prompt/dir1` から5画像を配置するよう更新。
+  - `tests/api/test_api_contract.py` のタグインデックス件数期待値を5画像/8タグ以上へ更新し、テストデータ参照パスを `dir1` 配下へ修正。
+- Decisions:
+  - Decision: メタデータ差分の検証は README 記載の prompt 値をそのまま期待値として採用する。
+  - Rationale: ドキュメント化済みの仕様を単一の真実源とし、画像更新時の不整合を即座に検知できるため。
+  - Impact: prompt extractor / tag index の単体・API契約テストの期待値が README と同期される。
+- Open Questions:
+  - Model名の抽出は現状 `prompt_extractor` の返却仕様外であり、将来仕様で必要なら別途抽出ロジックとテスト追加が必要。
+- Verification:
+  - `PYTHONPATH=. pytest tests/services/test_prompt_extractor.py tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 成功
+
+- Verification (retry log):
+  - `PYTHONPATH=. pytest tests/services/test_prompt_extractor.py tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 初回は `httpx` 未導入で失敗。
+  - `python -m pip install -r requirements-dev.txt` 実行後、同コマンドを再実行して `16 passed`。

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -86,11 +86,14 @@ def api_client_factory(free_tcp_port_factory):
 
 @pytest.fixture
 def copied_prompt_image_root(tmp_path: Path) -> Path:
-    source = Path("tests/resources/images_with_prompt")
+    source = Path("tests/resources/images_with_prompt/dir1")
     destination = tmp_path / "prompt_root"
     destination.mkdir()
     shutil.copy2(source / "00009.png", destination / "00009.png")
+    shutil.copy2(source / "00025.avif", destination / "00025.avif")
     nested = destination / "nested"
     nested.mkdir()
     shutil.copy2(source / "00010.avif", nested / "00010.avif")
+    shutil.copy2(source / "00027.avif", nested / "00027.avif")
+    shutil.copy2(source / "00029.avif", nested / "00029.avif")
     return destination

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -149,13 +149,13 @@ def test_tag_index_query_and_refresh(api_client_factory, copied_prompt_image_roo
     refresh_response = client.post("/api/tag-index/refresh")
     assert refresh_response.status_code == 200
     refreshed = refresh_response.json()
-    assert refreshed["indexed_files"] == 2
-    assert refreshed["indexed_tags"] >= 4
+    assert refreshed["indexed_files"] == 5
+    assert refreshed["indexed_tags"] >= 8
 
 
 def test_tag_index_query_works_on_startup_by_loading_db_without_rebuild(tmp_path, monkeypatch):
     static_dir = Path(__file__).resolve().parents[2] / "static"
-    source = Path("tests/resources/images_with_prompt")
+    source = Path("tests/resources/images_with_prompt/dir1")
     indexed_dir = tmp_path / "indexed"
     indexed_dir.mkdir()
     (indexed_dir / "nested").mkdir()

--- a/tests/services/test_prompt_extractor.py
+++ b/tests/services/test_prompt_extractor.py
@@ -2,20 +2,48 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from app.services.prompt_extractor import extract_generation_prompts
 
 
-def test_extract_generation_prompts_from_png_parameters_chunk():
-    result = extract_generation_prompts(Path("tests/resources/images_with_prompt/dir1/00009.png"))
+@pytest.mark.parametrize(
+    ("filename", "expected_positive", "expected_negative"),
+    [
+        (
+            "00009.png",
+            ["old male", "holding cat", "masterpiece", "best quality"],
+            ["worst quality", "bad quality", "bad anatomy", "bad hands"],
+        ),
+        (
+            "00010.avif",
+            ["old male", "holding cat", "masterpiece", "best quality"],
+            ["worst quality", "bad quality", "bad anatomy", "bad hands"],
+        ),
+        (
+            "00025.avif",
+            ["mountain", "scenery", "masterpiece", "best quality"],
+            [],
+        ),
+        (
+            "00027.avif",
+            ["knight", "solo", "masterpiece"],
+            ["bad anatomy", "bad hands"],
+        ),
+        (
+            "00029.avif",
+            ["old male", "solo"],
+            ["worst quality"],
+        ),
+    ],
+)
+def test_extract_generation_prompts_from_test_assets(
+    filename: str,
+    expected_positive: list[str],
+    expected_negative: list[str],
+):
+    result = extract_generation_prompts(Path("tests/resources/images_with_prompt/dir1") / filename)
 
     assert result is not None
-    assert result.positive == ["old male", "holding cat", "masterpiece", "best quality"]
-    assert result.negative == ["worst quality", "bad quality", "bad anatomy", "bad hands"]
-
-
-def test_extract_generation_prompts_from_avif_exif_user_comment():
-    result = extract_generation_prompts(Path("tests/resources/images_with_prompt/dir1/00025.avif"))
-
-    assert result is not None
-    assert result.positive == ["mountain", "scenery", "masterpiece", "best quality"]
-    assert result.negative == []
+    assert result.positive == expected_positive
+    assert result.negative == expected_negative

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -15,6 +15,9 @@ def test_build_index_and_query_with_and_or_modes(tmp_path: Path):
     nested_dir.mkdir(parents=True)
     shutil.copy2(source / "00009.png", nested_dir / "00009.png")
     shutil.copy2(source / "00010.avif", base_dir / "00010.avif")
+    shutil.copy2(source / "00025.avif", base_dir / "00025.avif")
+    shutil.copy2(source / "00027.avif", nested_dir / "00027.avif")
+    shutil.copy2(source / "00029.avif", base_dir / "00029.avif")
 
     service = TagIndexService(
         base_dir=base_dir,
@@ -26,13 +29,17 @@ def test_build_index_and_query_with_and_or_modes(tmp_path: Path):
     service.build_index(base_dir)
 
     assert "old male" in service.tag_to_file_ids
-    assert len(service.file_id_to_tags) == 2
+    assert "mountain" in service.tag_to_file_ids
+    assert "knight" in service.tag_to_file_ids
+    assert len(service.file_id_to_tags) == 5
     assert len(service.query(["old male", "best quality"], "and")) == 2
+    assert len(service.query(["solo"], "and")) == 2
+    assert len(service.query(["knight", "masterpiece"], "and")) == 1
     assert len(service.query(["holding cat", "unknown"], "or")) == 2
     assert service.query(["unknown"], "and") == []
 
     service.refresh_index()
-    assert len(service.file_metadata) == 2
+    assert len(service.file_metadata) == 5
 
 
 


### PR DESCRIPTION
### Motivation
- The test images containing generation metadata have been expanded and the README documents their prompt contents, so tests need broader coverage to detect regressions across variants.
- Increasing test patterns ensures the prompt extractor and tag indexer handle all recorded metadata forms (PNG parameters chunk and AVIF EXIF UserComment).

### Description
- Parameterized `tests/services/test_prompt_extractor.py` to validate positive/negative prompt extraction for all five fixture images (`00009`, `00010`, `00025`, `00027`, `00029`).
- Extended `tests/services/test_tag_index_service.py` to index the five images and added additional query assertions (including `solo` and `knight`) and updated in-memory/file-metadata expectations.
- Updated API fixtures and contract test in `tests/api/conftest.py` and `tests/api/test_api_contract.py` to copy the five fixture images from `tests/resources/images_with_prompt/dir1` and adjust expected `indexed_files`/`indexed_tags` counts.
- Added a handoff note at `docs/agent-handoff/tasks/2026-02-28-metadata-test-patterns.md` describing the changes, rationale, open questions, and verification steps.

### Testing
- Initial run `PYTHONPATH=. pytest tests/services/test_prompt_extractor.py tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` failed due to missing dev dependency (`httpx`).
- Installed dev dependencies with `python -m pip install -r requirements-dev.txt` and re-ran the same pytest command. 
- Verified result: `16 passed` for the targeted test set (all modified tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e22d9948832b85ceba1308e5f8cd)