### PR TITLE
Implement diff-based refresh for TagIndexService and add tests

### DIFF
--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -149,13 +149,15 @@ class TagIndexService:
         image_paths = self.repository.list_images_recursive(target_base)
 
         current_files: dict[str, tuple[Path, FileFingerprint]] = {}
-        for image_path in image_paths:
+        scan_progress = tqdm(image_paths, desc="[tag-index] refresh scan", unit="file", file=sys.stdout)
+        for image_path in scan_progress:
             resolved_path = image_path.resolve()
             stat_result = resolved_path.stat()
             current_files[str(resolved_path)] = (
                 resolved_path,
                 FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
             )
+        scan_progress.close()
 
         with self._connect() as conn:
             db_files: dict[str, IndexedRecord] = {}
@@ -174,14 +176,17 @@ class TagIndexService:
                 if path in db_files and current_files[path][1] != db_files[path].fingerprint
             )
 
+            reindex_paths = added_paths + modified_paths
+            apply_total = len(deleted_paths) + len(reindex_paths)
+            apply_progress = tqdm(total=apply_total, desc="[tag-index] refresh apply", unit="file", file=sys.stdout)
+
             for path in deleted_paths:
                 file_id = db_files[path].file_id
                 conn.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id,))
                 conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (file_id,))
+                apply_progress.update(1)
 
-            reindex_paths = added_paths + modified_paths
-            progress = tqdm(reindex_paths, desc="[tag-index] refresh", unit="file", file=sys.stdout)
-            for path in progress:
+            for path in reindex_paths:
                 image_path, fingerprint = current_files[path]
 
                 if path in db_files:
@@ -191,6 +196,7 @@ class TagIndexService:
 
                 prompt_result = extract_generation_prompts(image_path)
                 positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
+                apply_progress.update(1)
                 if not positive_tags:
                     continue
 
@@ -201,7 +207,7 @@ class TagIndexService:
                 )
                 for tag in positive_tags:
                     conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
-            progress.close()
+            apply_progress.close()
 
         self.load_index_from_db()
 

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -144,9 +145,27 @@ class TagIndexService:
         self.file_metadata = file_metadata
         return len(file_metadata)
 
+
+    def _list_images_recursive_with_progress(self, target_base: Path) -> list[Path]:
+        done = threading.Event()
+
+        def _tick_listing_progress() -> None:
+            progress = tqdm(desc="[tag-index] refresh list", unit="file", file=sys.stdout)
+            while not done.wait(0.1):
+                progress.update(1)
+            progress.close()
+
+        ticker = threading.Thread(target=_tick_listing_progress, daemon=True)
+        ticker.start()
+        try:
+            return self.repository.list_images_recursive(target_base)
+        finally:
+            done.set()
+            ticker.join()
+
     def refresh_index(self) -> None:
         target_base = self.base_dir.resolve()
-        image_paths = self.repository.list_images_recursive(target_base)
+        image_paths = self._list_images_recursive_with_progress(target_base)
 
         current_files: dict[str, tuple[Path, FileFingerprint]] = {}
         scan_progress = tqdm(image_paths, desc="[tag-index] refresh scan", unit="file", file=sys.stdout)

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -27,6 +27,12 @@ class IndexedFileMeta:
     fingerprint: FileFingerprint
 
 
+@dataclass(frozen=True)
+class IndexedRecord:
+    file_id: FileId
+    fingerprint: FileFingerprint
+
+
 class TagIndexService:
     def __init__(
         self,
@@ -139,9 +145,65 @@ class TagIndexService:
         return len(file_metadata)
 
     def refresh_index(self) -> None:
-        # NOTE: Full rebuild for now. `file_metadata` stores mtime/size fingerprints
-        # that enable future diff-based refreshes.
-        self.build_index(self.base_dir)
+        target_base = self.base_dir.resolve()
+        image_paths = self.repository.list_images_recursive(target_base)
+
+        current_files: dict[str, tuple[Path, FileFingerprint]] = {}
+        for image_path in image_paths:
+            resolved_path = image_path.resolve()
+            stat_result = resolved_path.stat()
+            current_files[str(resolved_path)] = (
+                resolved_path,
+                FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
+            )
+
+        with self._connect() as conn:
+            db_files: dict[str, IndexedRecord] = {}
+            rows = conn.execute("SELECT file_id, path, mtime_ns, size FROM indexed_files")
+            for file_id_raw, path, mtime_ns, size in rows:
+                db_files[path] = IndexedRecord(
+                    file_id=FileId(file_id_raw),
+                    fingerprint=FileFingerprint(mtime_ns=mtime_ns, size=size),
+                )
+
+            added_paths = sorted(path for path in current_files if path not in db_files)
+            deleted_paths = sorted(path for path in db_files if path not in current_files)
+            modified_paths = sorted(
+                path
+                for path in current_files
+                if path in db_files and current_files[path][1] != db_files[path].fingerprint
+            )
+
+            for path in deleted_paths:
+                file_id = db_files[path].file_id
+                conn.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id,))
+                conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (file_id,))
+
+            reindex_paths = added_paths + modified_paths
+            progress = tqdm(reindex_paths, desc="[tag-index] refresh", unit="file", file=sys.stdout)
+            for path in progress:
+                image_path, fingerprint = current_files[path]
+
+                if path in db_files:
+                    old_file_id = db_files[path].file_id
+                    conn.execute("DELETE FROM file_tags WHERE file_id = ?", (old_file_id,))
+                    conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (old_file_id,))
+
+                prompt_result = extract_generation_prompts(image_path)
+                positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
+                if not positive_tags:
+                    continue
+
+                file_id = FileId(self.registry.register(image_path))
+                conn.execute(
+                    "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                    (file_id, path, fingerprint.mtime_ns, fingerprint.size),
+                )
+                for tag in positive_tags:
+                    conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
+            progress.close()
+
+        self.load_index_from_db()
 
     def query(self, tags: list[str], mode: QueryMode) -> list[FileId]:
         normalized_tags = _normalize_tags(tags)

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -82,3 +82,21 @@
   - `python -m pip install -r requirements-dev.txt` : 成功
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（6 passed）
   - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）
+
+## Context Handoff
+- Goal: `refresh_index` の進捗表示を、待ち時間の体感に合う形へ改善する。
+- Changes:
+  - `app/services/tag_index_service.py` の `refresh_index` に2段階の進捗表示を追加。
+    - `[tag-index] refresh scan`: ファイル列挙後の fingerprint 収集（`stat`）を可視化。
+    - `[tag-index] refresh apply`: `deleted` 適用 + `added/modified` 再抽出・再挿入を可視化。
+  - `tests/services/test_tag_index_service.py` に `refresh_index` の進捗出力テストを追加し、scan/apply の両バーが標準出力に現れることを検証。
+- Decisions:
+  - Decision: 単一バーで全処理時間を近似するのではなく、scan/apply の2バーを明示する。
+  - Rationale: 「バーが出るまで待ち、出たら一瞬で終わる」体験を避け、実際に時間のかかる前処理を先に可視化するため。
+  - Impact: 差分件数が少ないケースでも、ユーザーは refresh 中の進行を早い段階で確認できる。
+- Open Questions:
+  - `list_images_recursive` 自体（rglob+sort）の待ち時間をさらに減らす/可視化する必要があるか。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（7 passed）
+  - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -64,3 +64,21 @@
   - DB破損時の詳細ログ（例: 例外種別）を追加で出すかどうか。
 - Verification:
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py -q` : 成功
+
+## Context Handoff
+- Goal: `refresh_index` を差分判定ベースへ更新し、追加/変更/削除のみをDB反映する。
+- Changes:
+  - `app/services/tag_index_service.py` の `refresh_index` を差分更新方式に変更し、`indexed_files(path, mtime_ns, size)` と現在ファイル一覧を比較して `added` / `modified` / `deleted` を分類。
+  - `added` と `modified` のみ `extract_generation_prompts` を再実行するようにし、`modified` は旧 `file_tags` / `indexed_files` を削除後に再挿入、`deleted` は両テーブルから削除する処理を追加。
+  - 差分反映完了後は `load_index_from_db()` を呼び出し、`tag_to_file_ids` などメモリインデクスをDB再読込で再同期。
+  - `tests/services/test_tag_index_service.py` に、追加ファイルのみ取込・変更ファイルのみ再抽出・削除ファイルの検索除外を検証するテストを追加。
+- Decisions:
+  - Decision: 差分反映後のメモリ同期は増分更新ではなく `load_index_from_db()` に統一。
+  - Rationale: 初期実装として複雑さを抑えつつ、DB整合性を単一経路で保証するため。
+  - Impact: リフレッシュ後のインメモリ状態は常にDB由来となり、更新ロジックの分岐バグを避けやすくなる。
+- Open Questions:
+  - `extract_generation_prompts` が `None` を返す画像を `indexed_files` に保持しない設計でよいか（未抽出ファイルは毎回 `added` 扱いで再試行される）。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（6 passed）
+  - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -100,3 +100,20 @@
   - `python -m pip install -r requirements-dev.txt` : 成功
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（7 passed）
   - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）
+
+## Context Handoff
+- Goal: refresh開始直後の待ち時間に、母数未確定の進捗を即時表示する。
+- Changes:
+  - `app/services/tag_index_service.py` に `_list_images_recursive_with_progress()` を追加し、`list_images_recursive` 実行中に別スレッドで `[tag-index] refresh list`（total未指定）を更新する実装を追加。
+  - `refresh_index` は上記ヘルパー経由でファイル一覧を取得するよう変更し、その後の `scan` / `apply` 2段階バーは維持。
+  - `tests/services/test_tag_index_service.py` の進捗テストを更新し、`refresh list` / `refresh scan` / `refresh apply` の出力を検証。
+- Decisions:
+  - Decision: ファイル列挙の重い区間は indeterminate バーを別スレッドで回して可視化する。
+  - Rationale: 列挙結果（母数）が確定する前に進捗表示を出し、体感上の無応答時間をなくすため。
+  - Impact: 大規模ディレクトリでも refresh 実行直後に進捗表示が始まる。
+- Open Questions:
+  - `build_index` 側にも同様の indeterminate 列挙バーを付与するか。
+- Verification:
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（7 passed）
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -94,6 +94,37 @@ def test_load_index_from_db_restores_in_memory_state(tmp_path: Path):
     assert len(loader.query(["old male", "best quality"], "and")) == 2
 
 
+
+
+def test_refresh_index_outputs_scan_and_apply_progress(tmp_path: Path, capsys, monkeypatch):
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    image_file = base_dir / "001.png"
+    image_file.write_bytes(b"v1")
+
+    def fake_extract(_image_path: Path):
+        class _Result:
+            positive = ["tag-001"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+    service.build_index(base_dir)
+    capsys.readouterr()
+
+    service.refresh_index()
+    captured = capsys.readouterr()
+
+    assert "[tag-index] refresh scan" in captured.out
+    assert "[tag-index] refresh apply" in captured.out
+
 def test_refresh_index_only_indexes_added_files(tmp_path: Path, monkeypatch):
     base_dir = tmp_path / "images"
     base_dir.mkdir()

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import sqlite3
 from pathlib import Path
 
 from app.repositories.filesystem import FileSystemRepository
@@ -91,3 +92,118 @@ def test_load_index_from_db_restores_in_memory_state(tmp_path: Path):
     assert len(loader.file_id_to_tags) == 2
     assert len(loader.file_metadata) == 2
     assert len(loader.query(["old male", "best quality"], "and")) == 2
+
+
+def test_refresh_index_only_indexes_added_files(tmp_path: Path, monkeypatch):
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    file1 = base_dir / "001.png"
+    file1.write_bytes(b"old")
+
+    extracted: list[str] = []
+
+    def fake_extract(image_path: Path):
+        extracted.append(image_path.name)
+
+        class _Result:
+            positive = [f"tag-{image_path.stem}"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+    service.build_index(base_dir)
+    assert extracted == ["001.png"]
+
+    file2 = base_dir / "002.png"
+    file2.write_bytes(b"new")
+    extracted.clear()
+
+    service.refresh_index()
+
+    assert extracted == ["002.png"]
+    assert len(service.file_metadata) == 2
+    assert len(service.query(["tag-001"], "and")) == 1
+    assert len(service.query(["tag-002"], "and")) == 1
+
+
+def test_refresh_index_only_reextracts_modified_files(tmp_path: Path, monkeypatch):
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    image_file = base_dir / "001.png"
+    image_file.write_bytes(b"v1")
+
+    call_count: dict[str, int] = {}
+
+    def fake_extract(image_path: Path):
+        call_count[image_path.name] = call_count.get(image_path.name, 0) + 1
+
+        class _Result:
+            positive = ["tag-v1"] if call_count[image_path.name] == 1 else ["tag-v2"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+    service.build_index(base_dir)
+    assert len(service.query(["tag-v1"], "and")) == 1
+
+    image_file.write_bytes(b"v2")
+    extracted_before = dict(call_count)
+
+    service.refresh_index()
+
+    assert call_count["001.png"] == extracted_before["001.png"] + 1
+    assert service.query(["tag-v1"], "and") == []
+    assert len(service.query(["tag-v2"], "and")) == 1
+
+
+def test_refresh_index_removes_deleted_files_from_results(tmp_path: Path, monkeypatch):
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    file1 = base_dir / "001.png"
+    file2 = base_dir / "002.png"
+    file1.write_bytes(b"a")
+    file2.write_bytes(b"b")
+
+    def fake_extract(image_path: Path):
+        class _Result:
+            positive = [f"tag-{image_path.stem}"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    db_path = tmp_path / "tag_index.sqlite3"
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=db_path,
+    )
+    service.build_index(base_dir)
+
+    file2.unlink()
+    service.refresh_index()
+
+    assert len(service.query(["tag-001"], "and")) == 1
+    assert service.query(["tag-002"], "and") == []
+
+    with sqlite3.connect(db_path) as conn:
+        indexed_count = conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0]
+        tag_count = conn.execute("SELECT COUNT(*) FROM file_tags WHERE tag = ?", ("tag-002",)).fetchone()[0]
+
+    assert indexed_count == 1
+    assert tag_count == 0

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -122,6 +122,7 @@ def test_refresh_index_outputs_scan_and_apply_progress(tmp_path: Path, capsys, m
     service.refresh_index()
     captured = capsys.readouterr()
 
+    assert "[tag-index] refresh list" in captured.out
     assert "[tag-index] refresh scan" in captured.out
     assert "[tag-index] refresh apply" in captured.out
 


### PR DESCRIPTION
### Motivation
- Reduce work and avoid unnecessary re-extraction by making `refresh_index` detect added/modified/deleted files and only reprocess changed files. 
- Keep the SQLite DB and in-memory tag indexes consistent after a refresh while keeping the implementation simple and robust. 

### Description
- Change `TagIndexService.refresh_index` to collect current recursive image listing and compare it with `indexed_files(path, mtime_ns, size)` to classify `added`, `modified`, and `deleted` paths. 
- Apply deletions and reindexing (for `added` + `modified`) inside a single DB connection so updates are applied together; `modified` rows are deleted before reinserting new tags and metadata. 
- Re-run `extract_generation_prompts` only for `added` and `modified` files and use `tqdm` for progress reporting. 
- Resynchronize in-memory indexes by calling `load_index_from_db()` after DB updates, add `IndexedRecord` helper type, and update task handoff docs. 
- Add unit tests in `tests/services/test_tag_index_service.py` to verify added-only extraction, modified-only re-extraction, and removal of deleted files from DB and query results. 

### Testing
- Installed dev deps with `python -m pip install -r requirements-dev.txt` to satisfy `tqdm` and test dependencies. 
- Ran service tests with `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` and observed `6 passed`. 
- Ran API contract tests with `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` and observed `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2fcd50bcc832ba6bcc9000339b619)