### PR TITLE
Parallelize tag extraction in TagIndexService and batch DB writes; add max_workers and tests

### DIFF
--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import threading
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -42,11 +44,15 @@ class TagIndexService:
         repository: FileSystemRepository,
         registry: ResourceRegistry,
         db_path: Path = Path("tag_index.sqlite3"),
+        max_workers: int | None = None,
     ) -> None:
         self.base_dir = base_dir
         self.repository = repository
         self.registry = registry
         self.db_path = db_path
+        self.max_workers = max_workers if max_workers is not None else min(os.cpu_count() or 1, 8)
+        if self.max_workers < 1:
+            raise ValueError("max_workers must be greater than 0")
 
         self.tag_to_file_ids: dict[str, set[FileId]] = {}
         self.file_id_to_tags: dict[FileId, list[str]] = {}
@@ -89,31 +95,72 @@ class TagIndexService:
         file_id_to_tags: dict[FileId, list[str]] = {}
         file_metadata: dict[FileId, IndexedFileMeta] = {}
 
+        failed_paths: list[str] = []
+        index_rows: list[tuple[str, str, int, int]] = []
+        tag_rows: list[tuple[str, str]] = []
+        batch_size = 200
+
         with self._connect() as conn:
             conn.execute("DELETE FROM file_tags")
             conn.execute("DELETE FROM indexed_files")
 
-            progress = tqdm(image_paths, desc="[tag-index] build", unit="file", file=sys.stdout)
-            for image_path in progress:
-                prompt_result = extract_generation_prompts(image_path)
-                positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
-                if positive_tags:
+            progress = tqdm(total=len(image_paths), desc="[tag-index] build", unit="file", file=sys.stdout)
+
+            with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+                futures: dict[Future, Path] = {
+                    executor.submit(extract_generation_prompts, image_path): image_path for image_path in image_paths
+                }
+                for future in as_completed(futures):
+                    image_path = futures[future]
+                    progress.update(1)
+                    try:
+                        prompt_result = future.result()
+                    except Exception:
+                        failed_paths.append(str(image_path.resolve()))
+                        continue
+
+                    positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
+                    if not positive_tags:
+                        continue
+
                     file_id = FileId(self.registry.register(image_path))
                     stat_result = image_path.stat()
                     fingerprint = FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size)
 
                     file_id_to_tags[file_id] = positive_tags
                     file_metadata[file_id] = IndexedFileMeta(path=str(image_path.resolve()), fingerprint=fingerprint)
-
-                    conn.execute(
-                        "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
-                        (file_id, str(image_path.resolve()), fingerprint.mtime_ns, fingerprint.size),
-                    )
+                    index_rows.append((file_id, str(image_path.resolve()), fingerprint.mtime_ns, fingerprint.size))
 
                     for tag in positive_tags:
                         tag_to_file_ids.setdefault(tag, set()).add(file_id)
-                        conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
+                        tag_rows.append((tag, file_id))
+
+                    if len(index_rows) >= batch_size:
+                        conn.executemany(
+                            "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                            index_rows,
+                        )
+                        index_rows.clear()
+
+                    if len(tag_rows) >= batch_size:
+                        conn.executemany("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", tag_rows)
+                        tag_rows.clear()
+
+            if index_rows:
+                conn.executemany(
+                    "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                    index_rows,
+                )
+            if tag_rows:
+                conn.executemany("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", tag_rows)
             progress.close()
+
+            if failed_paths:
+                tqdm.write(
+                    "[tag-index] build skipped files due to extraction errors "
+                    f"(count={len(failed_paths)}):\n" + "\n".join(failed_paths),
+                    file=sys.stdout,
+                )
 
         self.tag_to_file_ids = tag_to_file_ids
         self.file_id_to_tags = file_id_to_tags

--- a/docs/agent-handoff/tasks/2026-02-28-pytest-failure-fix.md
+++ b/docs/agent-handoff/tasks/2026-02-28-pytest-failure-fix.md
@@ -1,0 +1,15 @@
+## Context Handoff
+- Goal: `pytest` 実行時の失敗（`ModuleNotFoundError: app` / Playwright runtime 未導入）を解消し、標準手順でテストが通る状態にする。
+- Changes:
+  - `pytest.ini`
+    - `pythonpath = .` を追加し、`pytest` 単体実行でも `app` パッケージが import できるようにした。
+- Decisions:
+  - Decision: import 解決はテスト実行コマンド依存（`PYTHONPATH=.`）ではなく `pytest.ini` で吸収。
+  - Rationale: ローカル/CI 実行差分を減らし、再現性を高めるため。
+  - Impact: `pytest -q` だけでテスト収集が安定し、サービス/API テストが素直に実行される。
+- Open Questions:
+  - なし。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` -> 成功。
+  - `python -m playwright install --with-deps chromium` -> 成功。
+  - `pytest -q` -> 成功（23 passed）。

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-build-parallelization.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-build-parallelization.md
@@ -1,0 +1,22 @@
+## Context Handoff
+- Goal: `TagIndexService.build_index()` の prompt 抽出を並列化し、SQLite 書き込みはメインスレッドで順次バッチ反映する。
+- Changes:
+  - `app/services/tag_index_service.py`
+    - `build_index()` で `ThreadPoolExecutor` + `as_completed` を使って `extract_generation_prompts(image_path)` を並列実行。
+    - 完了件数ベースで `tqdm` を更新するよう `total=len(image_paths)` + `progress.update(1)` に変更。
+    - ワーカー失敗時は全体停止せず、失敗パスを集約して最後にログ出力。
+    - DB 反映はメインスレッドで `executemany` バッチ挿入（indexed_files / file_tags）に変更。
+    - `max_workers` 設定値を `__init__` に追加。デフォルトは `min(os.cpu_count() or 1, 8)`。
+  - `tests/services/test_tag_index_service.py`
+    - 失敗ファイルをスキップしログ出力されることを検証するテストを追加。
+    - `max_workers=0` を拒否するバリデーションテストを追加。
+- Decisions:
+  - Decision: まず `ThreadPoolExecutor` を採用。
+  - Rationale: 実装難易度を優先しつつ、I/O + 画像メタ抽出の並列化で改善効果を狙うため。
+  - Impact: `build_index()` の処理順は完了順（非決定）になるが、機能要件（索引結果）には影響しない。
+- Open Questions:
+  - CPU バウンドが支配的なケースでは `ProcessPoolExecutor` への切替評価が必要。
+  - 大規模データでの最適バッチサイズ（現在 200）は未計測。
+- Verification:
+  - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` -> 成功（9 passed）。
+  - `PYTHONPATH=. pytest tests/api/test_api_contract.py::test_tag_index_query_and_refresh -q` -> 失敗（`httpx` 未導入の環境依存）。

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+
+import pytest
 from pathlib import Path
 
 from app.repositories.filesystem import FileSystemRepository
@@ -239,3 +241,50 @@ def test_refresh_index_removes_deleted_files_from_results(tmp_path: Path, monkey
 
     assert indexed_count == 1
     assert tag_count == 0
+
+
+def test_build_index_skips_failed_extraction_and_reports_paths(tmp_path: Path, capsys, monkeypatch):
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    ok_file = base_dir / "ok.png"
+    ng_file = base_dir / "ng.png"
+    ok_file.write_bytes(b"ok")
+    ng_file.write_bytes(b"ng")
+
+    def fake_extract(image_path: Path):
+        if image_path.name == "ng.png":
+            raise RuntimeError("boom")
+
+        class _Result:
+            positive = ["tag-ok"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+        max_workers=2,
+    )
+
+    service.build_index(base_dir)
+    captured = capsys.readouterr()
+
+    assert len(service.file_metadata) == 1
+    assert len(service.query(["tag-ok"], "and")) == 1
+    assert "[tag-index] build skipped files due to extraction errors" in captured.out
+    assert str(ng_file.resolve()) in captured.out
+
+
+def test_build_index_rejects_invalid_max_workers(tmp_path: Path):
+    with pytest.raises(ValueError):
+        TagIndexService(
+            base_dir=tmp_path,
+            repository=FileSystemRepository(),
+            registry=ResourceRegistry(),
+            db_path=tmp_path / "tag_index.sqlite3",
+            max_workers=0,
+        )


### PR DESCRIPTION
### Motivation
- Speed up `TagIndexService.build_index()` by parallelizing prompt extraction while keeping SQLite writes serialized and robust. 
- Improve resilience by skipping files that fail extraction instead of aborting the entire build. 
- Provide a configurable worker limit with validation and add tests to cover the new behavior.

### Description
- Use `ThreadPoolExecutor` + `as_completed` to run `extract_generation_prompts(image_path)` in parallel and update `tqdm` with `total=len(image_paths)` and `progress.update(1)`. 
- Collect results and failures from workers, aggregate successful results in memory, and perform batched `executemany` inserts into `indexed_files` and `file_tags` (batch size 200) on the main thread. 
- Add `max_workers` parameter to `TagIndexService.__init__()` with default `min(os.cpu_count() or 1, 8)` and validation to reject values `< 1`. 
- Record and log skipped file paths when extraction raises exceptions, and avoid stopping the whole build on single-file errors. 
- Add `pytest.ini` with `pythonpath = .`, new tests in `tests/services/test_tag_index_service.py` for skipping failed extractions and invalid `max_workers`, and documentation handoff notes describing the changes.

### Testing
- Ran `pytest tests/services/test_tag_index_service.py -q` which passed (`9 passed`).
- Ran `PYTHONPATH=. pytest tests/api/test_api_contract.py::test_tag_index_query_and_refresh -q` which failed due to missing environment dependency (`httpx`) in that run. 
- Separately, with developer dependencies and Playwright installed as described in the docs, running `pytest -q` completed successfully (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30dd6ec54832ba7571e65f353ca9d)