### PR TITLE
Track directory mtimes and only rescan changed directories in tag index refresh

### DIFF
--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -36,6 +36,12 @@ class IndexedRecord:
     fingerprint: FileFingerprint
 
 
+@dataclass(frozen=True)
+class IndexedDirectory:
+    path: str
+    mtime_ns: int
+
+
 class TagIndexService:
     def __init__(
         self,
@@ -84,12 +90,18 @@ class TagIndexService:
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_file_tags_file_id ON file_tags(file_id);
+
+                CREATE TABLE IF NOT EXISTS indexed_directories (
+                    path TEXT PRIMARY KEY,
+                    mtime_ns INTEGER NOT NULL
+                );
                 """
             )
 
     def build_index(self, base_dir: Path | None = None) -> None:
         target_base = (base_dir or self.base_dir).resolve()
         image_paths = self.repository.list_images_recursive(target_base)
+        directory_rows = self._collect_directory_rows(target_base)
 
         tag_to_file_ids: dict[str, set[FileId]] = {}
         file_id_to_tags: dict[FileId, list[str]] = {}
@@ -103,6 +115,7 @@ class TagIndexService:
         with self._connect() as conn:
             conn.execute("DELETE FROM file_tags")
             conn.execute("DELETE FROM indexed_files")
+            conn.execute("DELETE FROM indexed_directories")
 
             progress = tqdm(total=len(image_paths), desc="[tag-index] build", unit="file", file=sys.stdout)
 
@@ -153,6 +166,10 @@ class TagIndexService:
                 )
             if tag_rows:
                 conn.executemany("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", tag_rows)
+            conn.executemany(
+                "INSERT INTO indexed_directories(path, mtime_ns) VALUES (?, ?)",
+                directory_rows,
+            )
             progress.close()
 
             if failed_paths:
@@ -193,11 +210,11 @@ class TagIndexService:
         return len(file_metadata)
 
 
-    def _list_images_recursive_with_progress(self, target_base: Path) -> list[Path]:
+    def _collect_directory_rows_with_progress(self, target_base: Path) -> list[tuple[str, int]]:
         done = threading.Event()
 
         def _tick_listing_progress() -> None:
-            progress = tqdm(desc="[tag-index] refresh list", unit="file", file=sys.stdout)
+            progress = tqdm(desc="[tag-index] refresh list", unit="dir", file=sys.stdout)
             while not done.wait(0.1):
                 progress.update(1)
             progress.close()
@@ -205,25 +222,23 @@ class TagIndexService:
         ticker = threading.Thread(target=_tick_listing_progress, daemon=True)
         ticker.start()
         try:
-            return self.repository.list_images_recursive(target_base)
+            return self._collect_directory_rows(target_base)
         finally:
             done.set()
             ticker.join()
 
+    def _collect_directory_rows(self, target_base: Path) -> list[tuple[str, int]]:
+        directories = [target_base, *(entry for entry in target_base.rglob("*") if entry.is_dir())]
+        rows: list[tuple[str, int]] = []
+        for directory in sorted(directories):
+            stat_result = directory.stat()
+            rows.append((str(directory.resolve()), stat_result.st_mtime_ns))
+        return rows
+
     def refresh_index(self) -> None:
         target_base = self.base_dir.resolve()
-        image_paths = self._list_images_recursive_with_progress(target_base)
-
-        current_files: dict[str, tuple[Path, FileFingerprint]] = {}
-        scan_progress = tqdm(image_paths, desc="[tag-index] refresh scan", unit="file", file=sys.stdout)
-        for image_path in scan_progress:
-            resolved_path = image_path.resolve()
-            stat_result = resolved_path.stat()
-            current_files[str(resolved_path)] = (
-                resolved_path,
-                FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
-            )
-        scan_progress.close()
+        directory_rows = self._collect_directory_rows_with_progress(target_base)
+        current_directories = {path: mtime_ns for path, mtime_ns in directory_rows}
 
         with self._connect() as conn:
             db_files: dict[str, IndexedRecord] = {}
@@ -234,13 +249,50 @@ class TagIndexService:
                     fingerprint=FileFingerprint(mtime_ns=mtime_ns, size=size),
                 )
 
-            added_paths = sorted(path for path in current_files if path not in db_files)
-            deleted_paths = sorted(path for path in db_files if path not in current_files)
+            db_directories: dict[str, IndexedDirectory] = {}
+            rows = conn.execute("SELECT path, mtime_ns FROM indexed_directories")
+            for path, mtime_ns in rows:
+                db_directories[path] = IndexedDirectory(path=path, mtime_ns=mtime_ns)
+
+            changed_directories = sorted(
+                path
+                for path, mtime_ns in current_directories.items()
+                if path not in db_directories or db_directories[path].mtime_ns != mtime_ns
+            )
+            deleted_directories = sorted(path for path in db_directories if path not in current_directories)
+
+            current_files: dict[str, tuple[Path, FileFingerprint]] = {}
+            scan_progress = tqdm(changed_directories, desc="[tag-index] refresh scan", unit="dir", file=sys.stdout)
+            for directory_path in scan_progress:
+                directory = Path(directory_path)
+                for image_path in self.repository.list_images(directory):
+                    resolved_path = image_path.resolve()
+                    stat_result = resolved_path.stat()
+                    current_files[str(resolved_path)] = (
+                        resolved_path,
+                        FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
+                    )
+            scan_progress.close()
+
+            db_files_in_changed_dirs = {
+                path: record
+                for path, record in db_files.items()
+                if str(Path(path).parent) in changed_directories
+            }
+
+            added_paths = sorted(path for path in current_files if path not in db_files_in_changed_dirs)
             modified_paths = sorted(
                 path
                 for path in current_files
-                if path in db_files and current_files[path][1] != db_files[path].fingerprint
+                if path in db_files_in_changed_dirs and current_files[path][1] != db_files_in_changed_dirs[path].fingerprint
             )
+            deleted_paths = sorted(path for path in db_files_in_changed_dirs if path not in current_files)
+
+            for directory_path in deleted_directories:
+                deleted_paths.extend(
+                    path for path in db_files if path == directory_path or path.startswith(f"{directory_path}{os.sep}")
+                )
+            deleted_paths = sorted(set(deleted_paths))
 
             reindex_paths = added_paths + modified_paths
             apply_total = len(deleted_paths) + len(reindex_paths)
@@ -273,6 +325,12 @@ class TagIndexService:
                 )
                 for tag in positive_tags:
                     conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
+
+            conn.execute("DELETE FROM indexed_directories")
+            conn.executemany(
+                "INSERT INTO indexed_directories(path, mtime_ns) VALUES (?, ?)",
+                directory_rows,
+            )
             apply_progress.close()
 
         self.load_index_from_db()

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -261,17 +261,25 @@ class TagIndexService:
             )
             deleted_directories = sorted(path for path in db_directories if path not in current_directories)
 
-            current_files: dict[str, tuple[Path, FileFingerprint]] = {}
-            scan_progress = tqdm(changed_directories, desc="[tag-index] refresh scan", unit="dir", file=sys.stdout)
-            for directory_path in scan_progress:
+            changed_directory_files: list[Path] = []
+            for directory_path in changed_directories:
                 directory = Path(directory_path)
-                for image_path in self.repository.list_images(directory):
-                    resolved_path = image_path.resolve()
-                    stat_result = resolved_path.stat()
-                    current_files[str(resolved_path)] = (
-                        resolved_path,
-                        FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
-                    )
+                changed_directory_files.extend(self.repository.list_images(directory))
+
+            current_files: dict[str, tuple[Path, FileFingerprint]] = {}
+            scan_progress = tqdm(
+                changed_directory_files,
+                desc="[tag-index] refresh scan",
+                unit="file",
+                file=sys.stdout,
+            )
+            for image_path in scan_progress:
+                resolved_path = image_path.resolve()
+                stat_result = resolved_path.stat()
+                current_files[str(resolved_path)] = (
+                    resolved_path,
+                    FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
+                )
             scan_progress.close()
 
             db_files_in_changed_dirs = {

--- a/docs/agent-handoff/README.md
+++ b/docs/agent-handoff/README.md
@@ -41,3 +41,16 @@ browser tool（Playwright）で画面確認に失敗した場合は、タスク�
 ```
 
 この記録により、「サーバ死活は正常だがブラウザ到達に失敗」なのか「UIレンダリング待機不足（遅延）」なのかを切り分けやすくする。
+
+## pytest実行前の依存導入チェック（再発防止）
+
+pytestを実行する前に、次を**必ずこの順で**実行する。
+
+```sh
+python -m pip install -r requirements-dev.txt
+python -m playwright install --with-deps chromium
+```
+
+- API/サービス層テストのみでも、まず `requirements-dev.txt` を入れてから実行する。
+- E2Eを含む `pytest` 実行では、browser未導入エラー回避のため Playwright の Chromium 導入まで完了させる。
+

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -151,3 +151,20 @@
   - `pytest -q` : 失敗（初回。Playwright browser executable未導入）
   - `python -m playwright install --with-deps chromium` : 成功
   - `pytest -q` : 成功（24 passed）
+
+## Context Handoff
+- Goal: refresh進捗表示のうち、scan工程をディレクトリ単位ではなくファイル単位で表示する。
+- Changes:
+  - `app/services/tag_index_service.py` の `refresh_index` で、`changed_directories` から対象ファイル一覧（`changed_directory_files`）を先に収集するよう変更。
+  - `refresh scan` の `tqdm` は `changed_directory_files` を対象にし、`unit="file"` でファイル数進捗を表示するようにした。
+  - `refresh list` は従来どおりディレクトリ列挙の indeterminate 表示（`unit="dir"`）を維持。
+- Decisions:
+  - Decision: list工程はディレクトリ、scan工程はファイルを単位に分離したまま表示する。
+  - Rationale: 体感時間の長い scan に対して、実作業量（ファイル数）に沿った進捗を出すため。
+  - Impact: scanバーがディレクトリ数ではなく対象画像ファイル総数ベースで進行する。
+- Open Questions:
+  - なし。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `python -m playwright install --with-deps chromium` : 成功
+  - `pytest -q` : 成功（24 passed）

--- a/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
+++ b/docs/agent-handoff/tasks/2026-02-28-tag-index-service.md
@@ -117,3 +117,37 @@
   - `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` : 成功（7 passed）
   - `python -m pip install -r requirements-dev.txt` : 成功
   - `PYTHONPATH=. pytest tests/api/test_api_contract.py -q` : 成功（8 passed）
+
+## Context Handoff
+- Goal: タグインデクスの refresh で、更新があったディレクトリのみを対象に差分処理する。
+- Changes:
+  - `app/services/tag_index_service.py` に `indexed_directories(path, mtime_ns)` テーブルと `IndexedDirectory` を追加し、`build_index` 時に全ディレクトリの更新時刻を保存するようにした。
+  - `refresh_index` は `indexed_directories` と現在のディレクトリmtimeを比較し、変更ディレクトリのみ `list_images` で走査する方式へ変更。削除ディレクトリ配下の既存インデクス行も削除対象に含めるようにした。
+  - refresh完了時に `indexed_directories` を全更新し、次回 refresh の比較基準を再保存するようにした。
+  - `tests/services/test_tag_index_service.py` を更新し、ディレクトリmtimeが変わらない更新では再抽出しないこと、および変更ディレクトリのみ再抽出されることを検証するテストを追加した。
+- Decisions:
+  - Decision: refreshの対象絞り込みは「ディレクトリmtimeの差分」を一次判定とし、変更ディレクトリ配下のみファイル差分（added/modified/deleted）を評価する。
+  - Rationale: `extract_generation_prompts` の再実行コストを減らし、変更が局所的なケースで refresh を高速化するため。
+  - Impact: 変更のないディレクトリ配下ファイルは再抽出されず、refreshの処理量が削減される。
+- Open Questions:
+  - ディレクトリmtimeが変わらないファイル内容更新（上書き）を追跡する必要がある場合、別途ファイル単位の監視戦略が必要。
+- Verification:
+  - `pytest tests/services/test_tag_index_service.py -q` : 成功（10 passed）
+  - `pytest tests/services/test_tag_index_service.py tests/api/test_api_contract.py::test_tag_index_query_and_refresh -q` : 失敗（`httpx` 未導入のため `tests/api/conftest.py` 読み込み時に `ModuleNotFoundError`）
+
+## Context Handoff
+- Goal: 前回PRで不足していたテスト実行手順（依存導入）を再発防止として明文化し、pytestを完走させる。
+- Changes:
+  - `docs/agent-handoff/README.md` に「pytest実行前の依存導入チェック」節を追加し、`requirements-dev.txt` と Playwright Chromium 導入を明示した。
+  - 依存導入後に `pytest -q` を再実行し、全テストが通ることを確認した。
+- Decisions:
+  - Decision: 手順はタスク個別ログだけでなく、共通運用ドキュメントにも残す。
+  - Rationale: 同種の手順抜け（pip install省略）を次回以降の作業でも防止するため。
+  - Impact: pytest実行時の初期失敗（`httpx` 未導入や Playwright browser 未導入）が再発しにくくなる。
+- Open Questions:
+  - なし。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `pytest -q` : 失敗（初回。Playwright browser executable未導入）
+  - `python -m playwright install --with-deps chromium` : 成功
+  - `pytest -q` : 成功（24 passed）

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -167,7 +167,7 @@ def test_refresh_index_only_indexes_added_files(tmp_path: Path, monkeypatch):
     assert len(service.query(["tag-002"], "and")) == 1
 
 
-def test_refresh_index_only_reextracts_modified_files(tmp_path: Path, monkeypatch):
+def test_refresh_index_skips_reextract_when_directory_mtime_unchanged(tmp_path: Path, monkeypatch):
     base_dir = tmp_path / "images"
     base_dir.mkdir()
     image_file = base_dir / "001.png"
@@ -199,9 +199,9 @@ def test_refresh_index_only_reextracts_modified_files(tmp_path: Path, monkeypatc
 
     service.refresh_index()
 
-    assert call_count["001.png"] == extracted_before["001.png"] + 1
-    assert service.query(["tag-v1"], "and") == []
-    assert len(service.query(["tag-v2"], "and")) == 1
+    assert call_count["001.png"] == extracted_before["001.png"]
+    assert len(service.query(["tag-v1"], "and")) == 1
+    assert service.query(["tag-v2"], "and") == []
 
 
 def test_refresh_index_removes_deleted_files_from_results(tmp_path: Path, monkeypatch):
@@ -288,3 +288,42 @@ def test_build_index_rejects_invalid_max_workers(tmp_path: Path):
             db_path=tmp_path / "tag_index.sqlite3",
             max_workers=0,
         )
+
+
+def test_refresh_index_reextracts_only_changed_directories(tmp_path: Path, monkeypatch):
+    base_dir = tmp_path / "images"
+    dir_a = base_dir / "a"
+    dir_b = base_dir / "b"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+
+    (dir_a / "001.png").write_bytes(b"a1")
+    (dir_b / "101.png").write_bytes(b"b1")
+
+    extracted: list[str] = []
+
+    def fake_extract(image_path: Path):
+        extracted.append(image_path.name)
+
+        class _Result:
+            positive = [f"tag-{image_path.stem}"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    service = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(),
+        db_path=tmp_path / "tag_index.sqlite3",
+    )
+    service.build_index(base_dir)
+
+    extracted.clear()
+    (dir_a / "002.png").write_bytes(b"a2")
+
+    service.refresh_index()
+
+    assert extracted == ["002.png"]
+    assert len(service.query(["tag-101"], "and")) == 1


### PR DESCRIPTION
### Motivation

- Reduce unnecessary re-extraction cost during `refresh_index` by avoiding reprocessing files in directories that haven't changed. 
- Improve user feedback during long directory enumeration by showing an indeterminate progress bar while listing directories.

### Description

- Add `indexed_directories` table and `IndexedDirectory` dataclass, and persist per-directory `mtime_ns` during `build_index` via `_collect_directory_rows`.
- Change `refresh_index` to compare current directory mtimes against `indexed_directories` and only `list_images` and re-extract files from directories that changed, while deleting index rows under removed directories.
- Replace the file-listing progress helper with `_collect_directory_rows_with_progress` that shows an indeterminate `[tag-index] refresh list` bar and update various progress bars to use `dir` units where appropriate.
- Update tests to reflect the new behavior: rename/adjust the previous modification test to assert skipping re-extraction when directory mtime is unchanged and add `test_refresh_index_reextracts_only_changed_directories`; update `tests/services/test_tag_index_service.py` accordingly, and add docs guidance for installing test dependencies.

### Testing

- Ran `PYTHONPATH=. pytest tests/services/test_tag_index_service.py -q` and observed success (`10 passed`).
- Addressed prior API test environment issues by installing dev dependencies with `python -m pip install -r requirements-dev.txt` and Playwright with `python -m playwright install --with-deps chromium`, and then ran `pytest -q` which succeeded (`24 passed`).
- Existing build and extraction failure handling tests remain present and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31839be38832b81e26c72cd7e3847)