### PR TITLE
Add async tag-index refresh job API and job status tracking

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -13,6 +13,8 @@ from app.models.schemas import (
     RenameDirectoryRequest,
     RenameDirectoryResponse,
     SubdirectoriesResponse,
+    TagIndexRefreshJobStartResponse,
+    TagIndexRefreshJobStatusResponse,
     TagIndexRefreshResponse,
     TagQueryRequest,
     TagQueryResponse,
@@ -127,12 +129,50 @@ def create_api_router(service: ImageService, tag_index_service: TagIndexService)
         )
 
 
+    @router.post("/tag-index/refresh-jobs", response_model=TagIndexRefreshJobStartResponse)
+    def start_tag_index_refresh_job() -> TagIndexRefreshJobStartResponse:
+        job_id = tag_index_service.start_refresh_job()
+        return TagIndexRefreshJobStartResponse(job_id=job_id)
+
+    @router.get("/tag-index/refresh-jobs/{job_id}", response_model=TagIndexRefreshJobStatusResponse)
+    def get_tag_index_refresh_job(job_id: str) -> TagIndexRefreshJobStatusResponse:
+        status = tag_index_service.get_refresh_job_status(job_id)
+        if status is None:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
+
+        return TagIndexRefreshJobStatusResponse(
+            job_id=status.job_id,
+            status=status.status,
+            progress_phase=status.progress_phase,
+            processed_files=status.processed_files,
+            total_files=status.total_files,
+            indexed_files=status.indexed_files,
+            indexed_tags=status.indexed_tags,
+            counters={
+                "added": status.counters.added,
+                "modified": status.counters.modified,
+                "deleted": status.counters.deleted,
+                "reindexed": status.counters.reindexed,
+            },
+            error=status.error,
+        )
+
     @router.post("/tag-index/refresh", response_model=TagIndexRefreshResponse)
     def refresh_tag_index() -> TagIndexRefreshResponse:
-        tag_index_service.refresh_index()
+        """Backward-compatible synchronous refresh API.
+
+        New clients should migrate to POST /api/tag-index/refresh-jobs and
+        poll GET /api/tag-index/refresh-jobs/{job_id}. This endpoint currently
+        waits for job completion and returns the final counts.
+        """
+        job_id = tag_index_service.start_refresh_job()
+        status = tag_index_service.wait_for_job(job_id)
+        if status.status == "failed":
+            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=status.error)
+
         return TagIndexRefreshResponse(
-            indexed_files=len(tag_index_service.file_id_to_tags),
-            indexed_tags=len(tag_index_service.tag_to_file_ids),
+            indexed_files=status.indexed_files,
+            indexed_tags=status.indexed_tags,
         )
 
     @router.post("/tag-index/query", response_model=TagQueryResponse)

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -46,6 +46,29 @@ class TagIndexRefreshResponse(BaseModel):
     indexed_tags: int
 
 
+class TagIndexRefreshJobStartResponse(BaseModel):
+    job_id: str
+
+
+class TagIndexRefreshJobCounters(BaseModel):
+    added: int
+    modified: int
+    deleted: int
+    reindexed: int
+
+
+class TagIndexRefreshJobStatusResponse(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "succeeded", "failed"]
+    progress_phase: Literal["queued", "listing", "scanning", "applying", "finalizing", "done", "failed"]
+    processed_files: int
+    total_files: int
+    indexed_files: int
+    indexed_tags: int
+    counters: TagIndexRefreshJobCounters
+    error: str | None = None
+
+
 class TagQueryRequest(BaseModel):
     tags: list[str]
     mode: Literal["and", "or"] = "or"

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -4,10 +4,11 @@ import os
 import sqlite3
 import sys
 import threading
+import uuid
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 from app.models.types import FileId
 from app.repositories.filesystem import FileSystemRepository
@@ -42,6 +43,27 @@ class IndexedDirectory:
     mtime_ns: int
 
 
+@dataclass
+class RefreshJobCounters:
+    added: int = 0
+    modified: int = 0
+    deleted: int = 0
+    reindexed: int = 0
+
+
+@dataclass
+class RefreshJobState:
+    job_id: str
+    status: Literal["queued", "running", "succeeded", "failed"] = "queued"
+    progress_phase: Literal["queued", "listing", "scanning", "applying", "finalizing", "done", "failed"] = "queued"
+    processed_files: int = 0
+    total_files: int = 0
+    indexed_files: int = 0
+    indexed_tags: int = 0
+    counters: RefreshJobCounters = field(default_factory=RefreshJobCounters)
+    error: str | None = None
+
+
 class TagIndexService:
     def __init__(
         self,
@@ -63,6 +85,10 @@ class TagIndexService:
         self.tag_to_file_ids: dict[str, set[FileId]] = {}
         self.file_id_to_tags: dict[FileId, list[str]] = {}
         self.file_metadata: dict[FileId, IndexedFileMeta] = {}
+
+        self._jobs: dict[str, RefreshJobState] = {}
+        self._job_events: dict[str, threading.Event] = {}
+        self._jobs_lock = threading.Lock()
 
         self._init_db()
 
@@ -97,6 +123,83 @@ class TagIndexService:
                 );
                 """
             )
+
+    def _snapshot_job(self, job_id: str) -> RefreshJobState | None:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            return RefreshJobState(
+                job_id=job.job_id,
+                status=job.status,
+                progress_phase=job.progress_phase,
+                processed_files=job.processed_files,
+                total_files=job.total_files,
+                indexed_files=job.indexed_files,
+                indexed_tags=job.indexed_tags,
+                counters=RefreshJobCounters(**asdict(job.counters)),
+                error=job.error,
+            )
+
+    def start_refresh_job(self) -> str:
+        job_id = uuid.uuid4().hex
+        with self._jobs_lock:
+            self._jobs[job_id] = RefreshJobState(job_id=job_id)
+            self._job_events[job_id] = threading.Event()
+
+        thread = threading.Thread(target=self._run_refresh_job, args=(job_id,), daemon=True)
+        thread.start()
+        return job_id
+
+    def _run_refresh_job(self, job_id: str) -> None:
+        try:
+            self.refresh_index(progress_callback=lambda **payload: self._update_job(job_id, **payload))
+            self._update_job(
+                job_id,
+                status="succeeded",
+                progress_phase="done",
+                processed_files=0,
+                total_files=0,
+                indexed_files=len(self.file_id_to_tags),
+                indexed_tags=len(self.tag_to_file_ids),
+            )
+        except Exception as exc:
+            self._update_job(
+                job_id,
+                status="failed",
+                progress_phase="failed",
+                error=str(exc),
+            )
+        finally:
+            event = self._job_events.get(job_id)
+            if event is not None:
+                event.set()
+
+    def _update_job(self, job_id: str, **fields: object) -> None:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            for key, value in fields.items():
+                if value is None:
+                    continue
+                if key == "counters" and isinstance(value, dict):
+                    job.counters = RefreshJobCounters(**value)
+                    continue
+                setattr(job, key, value)
+
+    def get_refresh_job_status(self, job_id: str) -> RefreshJobState | None:
+        return self._snapshot_job(job_id)
+
+    def wait_for_job(self, job_id: str) -> RefreshJobState:
+        event = self._job_events.get(job_id)
+        if event is None:
+            raise KeyError(job_id)
+        event.wait()
+        status = self._snapshot_job(job_id)
+        if status is None:
+            raise KeyError(job_id)
+        return status
 
     def build_index(self, base_dir: Path | None = None) -> None:
         target_base = (base_dir or self.base_dir).resolve()
@@ -235,9 +338,11 @@ class TagIndexService:
             rows.append((str(directory.resolve()), stat_result.st_mtime_ns))
         return rows
 
-    def refresh_index(self) -> None:
+    def refresh_index(self, progress_callback: Callable[..., None] | None = None) -> None:
         target_base = self.base_dir.resolve()
         directory_rows = self._collect_directory_rows_with_progress(target_base)
+        if progress_callback is not None:
+            progress_callback(status="running", progress_phase="listing")
         current_directories = {path: mtime_ns for path, mtime_ns in directory_rows}
 
         with self._connect() as conn:
@@ -273,13 +378,20 @@ class TagIndexService:
                 unit="file",
                 file=sys.stdout,
             )
-            for image_path in scan_progress:
+            for index, image_path in enumerate(scan_progress, start=1):
                 resolved_path = image_path.resolve()
                 stat_result = resolved_path.stat()
                 current_files[str(resolved_path)] = (
                     resolved_path,
                     FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
                 )
+                if progress_callback is not None:
+                    progress_callback(
+                        status="running",
+                        progress_phase="scanning",
+                        processed_files=index,
+                        total_files=len(changed_directory_files),
+                    )
             scan_progress.close()
 
             db_files_in_changed_dirs = {
@@ -304,13 +416,35 @@ class TagIndexService:
 
             reindex_paths = added_paths + modified_paths
             apply_total = len(deleted_paths) + len(reindex_paths)
+            if progress_callback is not None:
+                progress_callback(
+                    status="running",
+                    progress_phase="applying",
+                    processed_files=0,
+                    total_files=apply_total,
+                    counters={
+                        "added": len(added_paths),
+                        "modified": len(modified_paths),
+                        "deleted": len(deleted_paths),
+                        "reindexed": len(reindex_paths),
+                    },
+                )
             apply_progress = tqdm(total=apply_total, desc="[tag-index] refresh apply", unit="file", file=sys.stdout)
 
+            applied_count = 0
             for path in deleted_paths:
                 file_id = db_files[path].file_id
                 conn.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id,))
                 conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (file_id,))
                 apply_progress.update(1)
+                applied_count += 1
+                if progress_callback is not None:
+                    progress_callback(
+                        status="running",
+                        progress_phase="applying",
+                        processed_files=applied_count,
+                        total_files=apply_total,
+                    )
 
             for path in reindex_paths:
                 image_path, fingerprint = current_files[path]
@@ -323,6 +457,14 @@ class TagIndexService:
                 prompt_result = extract_generation_prompts(image_path)
                 positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
                 apply_progress.update(1)
+                applied_count += 1
+                if progress_callback is not None:
+                    progress_callback(
+                        status="running",
+                        progress_phase="applying",
+                        processed_files=applied_count,
+                        total_files=apply_total,
+                    )
                 if not positive_tags:
                     continue
 
@@ -342,6 +484,13 @@ class TagIndexService:
             apply_progress.close()
 
         self.load_index_from_db()
+        if progress_callback is not None:
+            progress_callback(
+                status="running",
+                progress_phase="finalizing",
+                indexed_files=len(self.file_id_to_tags),
+                indexed_tags=len(self.tag_to_file_ids),
+            )
 
     def query(self, tags: list[str], mode: QueryMode) -> list[FileId]:
         normalized_tags = _normalize_tags(tags)

--- a/docs/agent-handoff/tasks/2026-03-01-tag-index-refresh-jobs.md
+++ b/docs/agent-handoff/tasks/2026-03-01-tag-index-refresh-jobs.md
@@ -1,0 +1,19 @@
+## Context Handoff
+- Goal: タグインデックス再構築を非同期ジョブ化し、ジョブ状態を取得できるAPI契約へ拡張する。
+- Changes:
+  - `app/api/routes.py` に `POST /api/tag-index/refresh-jobs` と `GET /api/tag-index/refresh-jobs/{job_id}` を追加。
+  - 既存 `POST /api/tag-index/refresh` は後方互換の同期APIとして維持し、内部でジョブ開始→完了待ちに変更。
+  - `app/services/tag_index_service.py` にジョブ状態管理（queued/running/succeeded/failed、progress、counters）を追加。
+  - `app/models/schemas.py` にジョブ開始/状態レスポンスのスキーマを追加。
+  - `tests/api/test_api_contract.py` にジョブライフサイクルの契約テストを追加。
+- Decisions:
+  - Decision: ジョブ管理は専用サービス新設ではなく `TagIndexService` 内に集約した。
+  - Rationale: 既存の refresh 実装・状態（indexed counts）と同一責務で扱うほうが最小差分で回帰リスクが低い。
+  - Impact: API利用側は新規ジョブAPIへの段階移行が可能になり、既存クライアントは同期APIを継続利用できる。
+- Open Questions:
+  - 失敗ジョブや完了ジョブの保持期間（TTL）とクリーンアップ方針は未定。
+  - 既存同期APIの正式なdeprecate時期/告知方法は未決。
+- Verification:
+  - `python -m pip install -r requirements-dev.txt` : 成功
+  - `pytest tests/api/test_api_contract.py -q` : 成功（9 passed）
+  - `pytest tests/services/test_tag_index_service.py -q` : 成功（10 passed）

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -151,6 +152,43 @@ def test_tag_index_query_and_refresh(api_client_factory, copied_prompt_image_roo
     refreshed = refresh_response.json()
     assert refreshed["indexed_files"] == 5
     assert refreshed["indexed_tags"] >= 8
+
+
+def test_tag_index_refresh_job_lifecycle(api_client_factory, copied_prompt_image_root):
+    client = api_client_factory(copied_prompt_image_root)
+
+    start_response = client.post("/api/tag-index/refresh-jobs")
+    assert start_response.status_code == 200
+    job_id = start_response.json()["job_id"]
+    assert isinstance(job_id, str)
+
+    terminal = None
+    for _ in range(60):
+        status_response = client.get(f"/api/tag-index/refresh-jobs/{job_id}")
+        assert status_response.status_code == 200
+        payload = status_response.json()
+
+        assert payload["job_id"] == job_id
+        assert payload["status"] in {"queued", "running", "succeeded", "failed"}
+        assert payload["progress_phase"] in {"queued", "listing", "scanning", "applying", "finalizing", "done", "failed"}
+
+        counters = payload["counters"]
+        assert {"added", "modified", "deleted", "reindexed"}.issubset(counters.keys())
+        assert payload["processed_files"] >= 0
+        assert payload["total_files"] >= 0
+
+        if payload["status"] in {"succeeded", "failed"}:
+            terminal = payload
+            break
+
+        time.sleep(0.05)
+
+    assert terminal is not None
+    assert terminal["status"] == "succeeded"
+    assert terminal["progress_phase"] == "done"
+    assert terminal["indexed_files"] == 5
+    assert terminal["indexed_tags"] >= 8
+    assert terminal["error"] is None
 
 
 def test_tag_index_query_works_on_startup_by_loading_db_without_rebuild(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Provide a non-blocking way to rebuild the tag index and allow clients to poll progress and final results instead of blocking the HTTP request. 
- Preserve backward compatibility by keeping the existing synchronous `POST /api/tag-index/refresh` while encouraging migration to the new job API. 

### Description
- Add asynchronous job endpoints `POST /api/tag-index/refresh-jobs` (returns `job_id`) and `GET /api/tag-index/refresh-jobs/{job_id}` to expose job state and progress. 
- Implement job lifecycle management inside `TagIndexService` with `start_refresh_job`, `get_refresh_job_status`, and `wait_for_job`, plus in-memory job states and events to track `queued/running/succeeded/failed`, progress phase, processed/total files, counters, and errors. 
- Extend `refresh_index` to accept a `progress_callback` and emit `listing`, `scanning`, `applying`, and `finalizing` progress updates including counters (`added`, `modified`, `deleted`, `reindexed`) and final indexed counts. 
- Add new Pydantic schemas `TagIndexRefreshJobStartResponse` and `TagIndexRefreshJobStatusResponse` (with counters) and keep `TagIndexRefreshResponse` for the synchronous endpoint, which now starts a job and waits for completion (docstring notes migration guidance). 
- Update API contract tests by adding `test_tag_index_refresh_job_lifecycle` to verify job lifecycle, progress payload shape and terminal consistency, and record task notes under `docs/agent-handoff/tasks/2026-03-01-tag-index-refresh-jobs.md`. 

### Testing
- Installed dev deps with `python -m pip install -r requirements-dev.txt` and the install succeeded. 
- Ran `pytest tests/api/test_api_contract.py -q` and received `9 passed`. 
- Ran `pytest tests/services/test_tag_index_service.py -q` and received `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a41a8d16a8832bad4c1b2838580c9b)