### PR TITLE
fix: restore registry mappings when loading tag index

### DIFF
--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -295,8 +295,16 @@ class TagIndexService:
             indexed_files = conn.execute("SELECT file_id, path, mtime_ns, size FROM indexed_files")
             for file_id_raw, path, mtime_ns, size in indexed_files:
                 file_id = FileId(file_id_raw)
+                resolved_path = Path(path).resolve()
+                if not resolved_path.exists() or not resolved_path.is_file() or not resolved_path.is_relative_to(self.base_dir):
+                    continue
+
+                registered_file_id = FileId(self.registry.register(resolved_path))
+                if registered_file_id != file_id:
+                    continue
+
                 fingerprint = FileFingerprint(mtime_ns=mtime_ns, size=size)
-                file_metadata[file_id] = IndexedFileMeta(path=path, fingerprint=fingerprint)
+                file_metadata[file_id] = IndexedFileMeta(path=str(resolved_path), fingerprint=fingerprint)
                 file_id_to_tags[file_id] = []
 
             file_tags = conn.execute("SELECT tag, file_id FROM file_tags")

--- a/docs/agent-handoff/tasks/2026-03-01-filter-screen-temporary.md
+++ b/docs/agent-handoff/tasks/2026-03-01-filter-screen-temporary.md
@@ -38,3 +38,17 @@
   - `pytest tests/e2e -q`（1 passed）
   - `pytest tests/api/test_api_contract.py -q`（11 passed）
   - `npm --prefix frontend run build:bundle`（成功）
+
+## Context Handoff (filter image 404 fix)
+- Goal: 絞り込みモードで未閲覧画像の `/api/image/{file_id}` が 404 になる不具合を解消する。
+- Changes:
+  - `app/services/tag_index_service.py`: `load_index_from_db()` で DB から読み込んだ各画像パスを `ResourceRegistry` に再登録し、`file_id` 不整合や不正パスをスキップする検証を追加。
+  - `tests/services/test_tag_index_service.py`: DB ロード後でも `ResourceRegistry.resolve()` で画像 `file_id` を解決できることを確認する回帰テストを追加。
+- Decisions:
+  - Decision: DB ロード時にパスの存在確認・base_dir 配下確認・登録ID一致確認を行ってからメモリ状態に復元する。
+  - Rationale: タグ検索で返す `file_id` は DB 復元直後も画像APIで解決可能である必要があり、`_id_to_path` 未復元を防ぐため。
+  - Impact: サーバー再起動後でも絞り込みモードの画像表示がディレクトリモード未経由で成立する。
+- Open Questions:
+  - DB 内に古い `file_id` 形式が残っている場合は現状スキップ扱い。必要に応じて将来は再インデックス誘導を検討する。
+- Verification:
+  - `pytest tests/services/test_tag_index_service.py -q`（12 passed）

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -96,6 +96,37 @@ def test_load_index_from_db_restores_in_memory_state(tmp_path: Path):
     assert len(loader.query(["old male", "best quality"], "and")) == 2
 
 
+def test_load_index_from_db_registers_file_ids_for_image_resolution(tmp_path: Path):
+    source = Path("tests/resources/images_with_prompt/dir1")
+    base_dir = tmp_path / "images"
+    base_dir.mkdir()
+    target_image = base_dir / "00009.png"
+    shutil.copy2(source / "00009.png", target_image)
+    db_path = tmp_path / "tag_index.sqlite3"
+
+    builder_registry = ResourceRegistry(base_dir=base_dir)
+    builder = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=builder_registry,
+        db_path=db_path,
+    )
+    builder.build_index(base_dir)
+    indexed_file_id = builder_registry.register(target_image)
+
+    loader_registry = ResourceRegistry(base_dir=base_dir)
+    loader = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=loader_registry,
+        db_path=db_path,
+    )
+
+    loader.load_index_from_db()
+
+    assert loader_registry.resolve(indexed_file_id, base_dir=base_dir, expect_directory=False) == target_image.resolve()
+
+
 
 
 def test_refresh_index_outputs_scan_and_apply_progress(tmp_path: Path, capsys, monkeypatch):


### PR DESCRIPTION
### Motivation
- Fix a bug where images returned by the tag-index (filter mode) produced 404 from `/api/image/{file_id}` after server restart because the `ResourceRegistry` mappings were not restored from the DB index.
- Ensure that images discovered by the tag index are resolvable by `file_id` immediately after DB load without requiring a prior directory-mode visit.

### Description
- Update `TagIndexService.load_index_from_db()` to validate each DB row by checking the resolved path exists, is a file, and is under `base_dir`, and to skip rows that fail these checks.
- Re-register each valid image path into `ResourceRegistry` and verify the deterministic registered `file_id` matches the DB `file_id`, skipping mismatches to avoid restoring stale IDs, and store resolved paths into `file_metadata`.
- Add a regression test `test_load_index_from_db_registers_file_ids_for_image_resolution` in `tests/services/test_tag_index_service.py` that verifies a `file_id` loaded from DB can be resolved via `ResourceRegistry.resolve()` after `load_index_from_db()`.
- Append a handoff note in `docs/agent-handoff/tasks/2026-03-01-filter-screen-temporary.md` describing the change, rationale, and verification.

### Testing
- Ran `pytest tests/services/test_tag_index_service.py -q` and all tests passed (`12 passed`).
- The new regression test confirms that DB-loaded `file_id`s are resolvable by the `ResourceRegistry` after `load_index_from_db()`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46b69ac90832b8636eb419420aa17)