### PR TITLE
fix: normalize prompt weight notation in tag extraction

### DIFF
--- a/app/services/prompt_extractor.py
+++ b/app/services/prompt_extractor.py
@@ -243,11 +243,21 @@ def _tokenize_prompt_terms(part: str) -> list[str]:
             continue
 
         token = token.strip('"\'')
-        weighted = re.match(r"^\((.+):\s*-?\d+(?:\.\d+)?\)$", token)
-        if weighted:
-            token = weighted.group(1).strip()
+        token = _strip_weight_notation(token)
 
         if token:
             terms.append(token)
 
     return terms
+
+
+def _strip_weight_notation(token: str) -> str:
+    escaped_open_placeholder = "\uE000"
+    escaped_close_placeholder = "\uE001"
+
+    normalized = token.replace(r"\(", escaped_open_placeholder).replace(r"\)", escaped_close_placeholder)
+    normalized = re.sub(r"(?<!\\)[()]", "", normalized)
+    normalized = re.sub(r"(?:\s*:\s*-?\d+(?:\.\d+)?)+\s*$", "", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+
+    return normalized.replace(escaped_open_placeholder, r"\(").replace(escaped_close_placeholder, r"\)")

--- a/docs/agent-handoff/tasks/2026-03-02-prompt-weight-parsing.md
+++ b/docs/agent-handoff/tasks/2026-03-02-prompt-weight-parsing.md
@@ -1,0 +1,16 @@
+## Context Handoff
+- Goal:
+  - タグ生成時のプロンプト解析で、ウェイト記法由来の括弧や数値断片がタグに残る問題を解消する。
+- Changes:
+  - `app/services/prompt_extractor.py` に `_strip_weight_notation` を追加し、`_tokenize_prompt_terms` で共通利用するよう変更。
+  - 未エスケープ括弧の除去、末尾の数値ウェイト（`:1.2`, `:1:2` など）除去、空白正規化を実装。
+  - `tests/services/test_prompt_extractor.py` にウェイト記法の崩れ・部分適用・エスケープ括弧の保持ケースを追加。
+- Decisions:
+  - Decision: `\(` / `\)` はプレースホルダに退避してから括弧除去する方式を採用。
+  - Rationale: エスケープ括弧は文字列として保持し、ウェイト記法の括弧のみ除去するため。
+  - Impact: タグインデックスに流入するタグの正規化精度が向上し、意図しないタグ分断を低減。
+- Open Questions:
+  - `tag:2025` のような末尾が数値の正当タグは現状維持だが、将来的に厳密仕様化が必要な可能性あり。
+- Verification:
+  - `pytest tests/services/test_prompt_extractor.py -q` (pass)
+  - `pytest tests/services/test_tag_index_service.py -q` (pass)

--- a/tests/services/test_prompt_extractor.py
+++ b/tests/services/test_prompt_extractor.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from app.services.prompt_extractor import extract_generation_prompts
+from app.services.prompt_extractor import _tokenize_prompt_terms, extract_generation_prompts
 
 
 @pytest.mark.parametrize(
@@ -47,3 +47,19 @@ def test_extract_generation_prompts_from_test_assets(
     assert result is not None
     assert result.positive == expected_positive
     assert result.negative == expected_negative
+
+
+@pytest.mark.parametrize(
+    ("part", "expected"),
+    [
+        ("(car", ["car"]),
+        ("boy)", ["boy"]),
+        ("boy:1:2)", ["boy"]),
+        ("(boy)", ["boy"]),
+        ("big (cat)", ["big cat"]),
+        (r"aqua \(konosuba\)", [r"aqua \(konosuba\)"]),
+        ("(masterpiece:1.2), best quality", ["masterpiece", "best quality"]),
+    ],
+)
+def test_tokenize_prompt_terms_strips_weight_notation_variants(part: str, expected: list[str]) -> None:
+    assert _tokenize_prompt_terms(part) == expected


### PR DESCRIPTION
### Motivation
- Prompt parsing left fragments of weight notation (unbalanced parentheses and trailing weight numbers) inside generated tags, causing incorrect tag tokens.
- The goal is to remove only weight-related syntax while preserving escaped parentheses like `\(` / `\)` and handling partially-weighted tokens (e.g. `big (cat)`).

### Description
- Added `_strip_weight_notation(token: str) -> str` to `app/services/prompt_extractor.py` to centralize normalization behavior.
- Updated `_tokenize_prompt_terms` to call `_strip_weight_notation` and perform trimming/quoting as before.
- `_strip_weight_notation` preserves escaped parentheses, removes unescaped `(` and `)`, strips trailing weight suffixes like `:1.2` or `:1:2`, and normalizes whitespace.
- Added focused tests to `tests/services/test_prompt_extractor.py` that cover unbalanced parentheses, trailing-weight variants, partially-weighted tokens, and escaped-parentheses preservation, and added a task log in `docs/agent-handoff/tasks/2026-03-02-prompt-weight-parsing.md` describing the change and rationale.

### Testing
- Ran `pytest tests/services/test_prompt_extractor.py -q` and the suite passed (`12 passed`).
- Ran `pytest tests/services/test_tag_index_service.py -q` to ensure no regressions in tag index usage and it passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58bf2c4b8832badbbe8944d5eab0b)