### PR TITLE
Optimize startup tag-index load with directory-based reconciliation

### DIFF
--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -55,15 +55,22 @@ class ResourceRegistry:
         prefix = "d" if is_directory else "f"
         return f"{prefix}_{digest}"
 
-    def register(self, path: Path) -> str:
+    def register(self, path: Path, *, is_directory: bool | None = None) -> str:
         resolved_path = path.resolve()
         with self._lock:
             resource_id = self._path_to_id.get(resolved_path)
             if resource_id is None:
-                resource_id = self._generate_resource_id(resolved_path, is_directory=resolved_path.is_dir())
+                resolved_is_directory = resolved_path.is_dir() if is_directory is None else is_directory
+                resource_id = self._generate_resource_id(resolved_path, is_directory=resolved_is_directory)
                 self._path_to_id[resolved_path] = resource_id
                 self._id_to_path[resource_id] = resolved_path
             return resource_id
+
+    def register_file(self, path: Path) -> str:
+        return self.register(path, is_directory=False)
+
+    def register_directory(self, path: Path) -> str:
+        return self.register(path, is_directory=True)
 
     def discard(self, path: Path) -> None:
         resolved_path = path.resolve()
@@ -96,7 +103,7 @@ class ImageService:
 
     def list_subdirectories(self) -> list[DirectoryEntry]:
         subdirectories = self.repository.list_subdirectories(self.base_dir)
-        return [DirectoryEntry(directory_id=self.registry.register(path), name=path.name) for path in subdirectories]
+        return [DirectoryEntry(directory_id=self.registry.register_directory(path), name=path.name) for path in subdirectories]
 
     def list_images(self, directory_id: DirectoryId) -> tuple[Path, list[ImageEntry]]:
         directory = self.registry.resolve(directory_id, base_dir=self.base_dir, expect_directory=True)
@@ -104,7 +111,7 @@ class ImageService:
             raise ResourceNotFoundError
 
         images = self.repository.list_images(directory)
-        image_entries = [ImageEntry(file_id=self.registry.register(path), name=path.name) for path in images]
+        image_entries = [ImageEntry(file_id=self.registry.register_file(path), name=path.name) for path in images]
         return directory, image_entries
 
     def resolve_image(self, file_id: FileId) -> Path:
@@ -122,7 +129,7 @@ class ImageService:
         if not directory_path.is_relative_to(self.base_dir):
             raise ResourceNotFoundError
 
-        directory_id = self.registry.register(directory_path)
+        directory_id = self.registry.register_directory(directory_path)
         image_entry = ImageEntry(file_id=file_id, name=file_path.name)
         return directory_id, directory_path.name, image_entry
 
@@ -156,5 +163,5 @@ class ImageService:
             raise ServiceError from exc
 
         self.registry.discard(current_directory)
-        new_directory_id = self.registry.register(destination)
+        new_directory_id = self.registry.register_directory(destination)
         return new_directory_id, current_directory.name, stripped_name

--- a/app/services/tag_index_service.py
+++ b/app/services/tag_index_service.py
@@ -239,7 +239,7 @@ class TagIndexService:
                     if not positive_tags:
                         continue
 
-                    file_id = FileId(self.registry.register(image_path))
+                    file_id = FileId(self.registry.register_file(image_path))
                     stat_result = image_path.stat()
                     fingerprint = FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size)
 
@@ -286,21 +286,21 @@ class TagIndexService:
         self.file_id_to_tags = file_id_to_tags
         self.file_metadata = file_metadata
 
-    def load_index_from_db(self) -> int:
+    def load_index_from_db(self, *, reconcile_directories: bool = True) -> int:
         tag_to_file_ids: dict[str, set[FileId]] = {}
         file_id_to_tags: dict[FileId, list[str]] = {}
         file_metadata: dict[FileId, IndexedFileMeta] = {}
 
         with self._connect() as conn:
+            if reconcile_directories:
+                self._reconcile_directory_index(conn)
+
             indexed_files = conn.execute("SELECT file_id, path, mtime_ns, size FROM indexed_files")
             for file_id_raw, path, mtime_ns, size in indexed_files:
                 file_id = FileId(file_id_raw)
                 resolved_path = Path(path).resolve()
-                if not resolved_path.exists() or not resolved_path.is_file():
-                    continue
-
                 if resolved_path.is_relative_to(self.base_dir):
-                    registered_file_id = FileId(self.registry.register(resolved_path))
+                    registered_file_id = FileId(self.registry.register_file(resolved_path))
                     if registered_file_id != file_id:
                         continue
 
@@ -320,6 +320,106 @@ class TagIndexService:
         self.file_id_to_tags = file_id_to_tags
         self.file_metadata = file_metadata
         return len(file_metadata)
+
+    def _reconcile_directory_index(self, conn: sqlite3.Connection) -> None:
+        target_base = self.base_dir.resolve()
+        directory_rows = self._collect_directory_rows_with_progress(target_base)
+        current_directories = {path: mtime_ns for path, mtime_ns in directory_rows}
+
+        db_directories: dict[str, IndexedDirectory] = {}
+        rows = conn.execute("SELECT path, mtime_ns FROM indexed_directories")
+        for path, mtime_ns in rows:
+            db_directories[path] = IndexedDirectory(path=path, mtime_ns=mtime_ns)
+
+        changed_directories = sorted(
+            path
+            for path, mtime_ns in current_directories.items()
+            if path not in db_directories or db_directories[path].mtime_ns != mtime_ns
+        )
+        deleted_directories = sorted(path for path in db_directories if path not in current_directories)
+
+        if not changed_directories and not deleted_directories:
+            return
+
+        self._reconcile_files_for_directories(conn, changed_directories, deleted_directories)
+
+        conn.execute("DELETE FROM indexed_directories")
+        conn.executemany(
+            "INSERT INTO indexed_directories(path, mtime_ns) VALUES (?, ?)",
+            directory_rows,
+        )
+
+    def _reconcile_files_for_directories(
+        self,
+        conn: sqlite3.Connection,
+        changed_directories: list[str],
+        deleted_directories: list[str],
+    ) -> None:
+        db_files_in_changed_dirs: dict[str, IndexedRecord] = {}
+
+        for directory_path in changed_directories:
+            for file_id_raw, path, mtime_ns, size in conn.execute(
+                "SELECT file_id, path, mtime_ns, size FROM indexed_files WHERE path LIKE ?",
+                (f"{directory_path}{os.sep}%",),
+            ):
+                db_files_in_changed_dirs[path] = IndexedRecord(
+                    file_id=FileId(file_id_raw),
+                    fingerprint=FileFingerprint(mtime_ns=mtime_ns, size=size),
+                )
+
+        current_files: dict[str, tuple[Path, FileFingerprint]] = {}
+        for directory_path in changed_directories:
+            directory = Path(directory_path)
+            if not directory.exists() or not directory.is_dir():
+                continue
+            for image_path in self.repository.list_images(directory):
+                stat_result = image_path.stat()
+                current_files[str(image_path.resolve())] = (
+                    image_path,
+                    FileFingerprint(mtime_ns=stat_result.st_mtime_ns, size=stat_result.st_size),
+                )
+
+        added_paths = sorted(path for path in current_files if path not in db_files_in_changed_dirs)
+        modified_paths = sorted(
+            path
+            for path in current_files
+            if path in db_files_in_changed_dirs and current_files[path][1] != db_files_in_changed_dirs[path].fingerprint
+        )
+        deleted_paths = sorted(path for path in db_files_in_changed_dirs if path not in current_files)
+
+        for directory_path in deleted_directories:
+            for file_id_raw, path in conn.execute(
+                "SELECT file_id, path FROM indexed_files WHERE path LIKE ?",
+                (f"{directory_path}{os.sep}%",),
+            ):
+                conn.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id_raw,))
+                conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (file_id_raw,))
+
+        for path in deleted_paths:
+            file_id = db_files_in_changed_dirs[path].file_id
+            conn.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id,))
+            conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (file_id,))
+
+        for path in added_paths + modified_paths:
+            image_path, fingerprint = current_files[path]
+
+            if path in db_files_in_changed_dirs:
+                old_file_id = db_files_in_changed_dirs[path].file_id
+                conn.execute("DELETE FROM file_tags WHERE file_id = ?", (old_file_id,))
+                conn.execute("DELETE FROM indexed_files WHERE file_id = ?", (old_file_id,))
+
+            prompt_result = extract_generation_prompts(image_path)
+            positive_tags = _normalize_tags(prompt_result.positive if prompt_result else [])
+            if not positive_tags:
+                continue
+
+            file_id = FileId(self.registry.register_file(image_path))
+            conn.execute(
+                "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
+                (file_id, path, fingerprint.mtime_ns, fingerprint.size),
+            )
+            for tag in positive_tags:
+                conn.execute("INSERT INTO file_tags(tag, file_id) VALUES (?, ?)", (tag, file_id))
 
 
     def _collect_directory_rows_with_progress(self, target_base: Path) -> list[tuple[str, int]]:
@@ -477,7 +577,7 @@ class TagIndexService:
                 if not positive_tags:
                     continue
 
-                file_id = FileId(self.registry.register(image_path))
+                file_id = FileId(self.registry.register_file(image_path))
                 conn.execute(
                     "INSERT INTO indexed_files(file_id, path, mtime_ns, size) VALUES (?, ?, ?, ?)",
                     (file_id, path, fingerprint.mtime_ns, fingerprint.size),
@@ -492,7 +592,7 @@ class TagIndexService:
             )
             apply_progress.close()
 
-        self.load_index_from_db()
+        self.load_index_from_db(reconcile_directories=False)
         if progress_callback is not None:
             progress_callback(
                 status="running",

--- a/docs/agent-handoff/tasks/2026-03-02-startup-directory-reconcile.md
+++ b/docs/agent-handoff/tasks/2026-03-02-startup-directory-reconcile.md
@@ -1,0 +1,25 @@
+## Context Handoff
+- Goal:
+  - タグインデックスDBが既に存在する起動時に、全ファイルを逐次検証するコストを削減するため、ディレクトリ差分起点で整合処理する。
+- Changes:
+  - `app/services/tag_index_service.py`
+    - `load_index_from_db(reconcile_directories: bool = True)` を追加し、起動時に `indexed_directories` と実ディレクトリの差分を先に判定。
+    - 差分があるディレクトリだけ `_reconcile_files_for_directories()` で実ファイルとDBを整合。
+    - 差分がない場合はファイル単位の存在チェックをスキップしてメモリ復元のみ実施。
+    - `refresh_index()` の最後は `load_index_from_db(reconcile_directories=False)` を呼び、二重スキャンを回避。
+    - ファイルID登録は `registry.register_file()` を利用して無駄な `is_dir()` 判定を削減。
+  - `app/services/image_service.py`
+    - `ResourceRegistry.register(path, is_directory=None)` に拡張。
+    - `register_file()` / `register_directory()` を追加し、呼び出し側を用途別APIに置換。
+  - `tests/services/test_tag_index_service.py`
+    - `test_load_index_from_db_reconciles_only_changed_directories` を追加し、変更ディレクトリの新規ファイルのみ再抽出されることを検証。
+- Decisions:
+  - Decision: 起動時整合の主キーを「ファイル全件走査」から「ディレクトリmtime差分」に変更。
+  - Rationale: 起動待ちの主因である全件存在チェックを避け、変更がないケースを最短経路で通すため。
+  - Impact: ディレクトリmtimeが変わらない特殊ケースでは差分検出できないが、既存 `refresh_index()` と同等の前提で運用する。
+- Open Questions:
+  - ファイルシステムや同期ツールによっては、ファイル更新時に親ディレクトリmtimeが変化しない環境がありうるため、オプションで強制フル検証モードを残すかは要検討。
+- Verification:
+  - `pytest tests/services/test_tag_index_service.py -q` -> 成功（13 passed）
+  - `python -m pip install -r requirements-dev.txt` -> 成功（不足依存の `httpx` / `playwright` を導入）
+  - `pytest tests/api/test_api_contract.py::test_tag_index_query_and_refresh -q` -> 成功（1 passed）

--- a/tests/services/test_tag_index_service.py
+++ b/tests/services/test_tag_index_service.py
@@ -408,3 +408,53 @@ def test_file_ids_are_stable_across_restarts_for_build_and_refresh(tmp_path: Pat
 
     assert built_file_ids == rebuilt_file_ids
     assert built_file_ids == refreshed_file_ids
+
+def test_load_index_from_db_reconciles_only_changed_directories(tmp_path: Path, monkeypatch):
+    base_dir = tmp_path / "images"
+    dir_a = base_dir / "a"
+    dir_b = base_dir / "b"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+
+    file_a = dir_a / "001.png"
+    file_b = dir_b / "101.png"
+    file_a.write_bytes(b"a1")
+    file_b.write_bytes(b"b1")
+
+    extracted: list[str] = []
+
+    def fake_extract(image_path: Path):
+        extracted.append(image_path.name)
+
+        class _Result:
+            positive = [f"tag-{image_path.stem}"]
+
+        return _Result()
+
+    monkeypatch.setattr("app.services.tag_index_service.extract_generation_prompts", fake_extract)
+
+    db_path = tmp_path / "tag_index.sqlite3"
+    builder = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(base_dir=base_dir),
+        db_path=db_path,
+    )
+    builder.build_index(base_dir)
+
+    extracted.clear()
+    (dir_a / "002.png").write_bytes(b"a2")
+
+    loader = TagIndexService(
+        base_dir=base_dir,
+        repository=FileSystemRepository(),
+        registry=ResourceRegistry(base_dir=base_dir),
+        db_path=db_path,
+    )
+    loaded_count = loader.load_index_from_db()
+
+    assert extracted == ["002.png"]
+    assert loaded_count == 3
+    assert len(loader.query(["tag-001"], "and")) == 1
+    assert len(loader.query(["tag-002"], "and")) == 1
+    assert len(loader.query(["tag-101"], "and")) == 1


### PR DESCRIPTION
## Summary
- change `TagIndexService.load_index_from_db()` to reconcile by directory mtime deltas before rebuilding in-memory maps
- add directory-scoped file reconciliation for changed/deleted directories instead of startup-time full file existence scans
- avoid duplicate post-refresh scans by loading DB state with `reconcile_directories=False` after `refresh_index()`
- add `ResourceRegistry.register_file()` / `register_directory()` and switch service callers to explicit file/dir registration
- add a service test to verify startup load re-extracts only files in changed directories
- record task context in `docs/agent-handoff/tasks/2026-03-02-startup-directory-reconcile.md`

## Verification
- `pytest tests/services/test_tag_index_service.py -q` (13 passed)
- `pytest tests/api/test_api_contract.py::test_tag_index_query_and_refresh -q` (1 passed)
- `python -m pip install -r requirements-dev.txt` (installed missing `httpx`/`playwright` required for API test env)

## Notes
- This keeps the existing mtime-based change-detection assumption: if a filesystem fails to update parent directory mtime on file changes, delta detection may miss updates until a refresh path that observes the change is triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5885cdeb4832ba2bbe7c77ed506f8)